### PR TITLE
Bugfix issue 5

### DIFF
--- a/src/dist.c
+++ b/src/dist.c
@@ -133,7 +133,7 @@ inform_dist* inform_dist_copy(inform_dist const *src, inform_dist *dest)
         return dest;
     }
     // copy the contents of the histogram from the source to the destination
-    memcpy(src->histogram, dest->histogram, src->size * sizeof(uint64_t));
+    memcpy(dest->histogram, src->histogram, src->size * sizeof(uint64_t));
     // set the counts appropriately
     dest->counts = src->counts;
     // return the modified destination

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -179,6 +179,7 @@ CTEST(Distribution, CopyToNULL)
     for (size_t i = 0; i < inform_dist_size(source); ++i)
     {
         ASSERT_EQUAL(inform_dist_get(source,i), inform_dist_get(dest,i));
+    	ASSERT_EQUAL(i+1, inform_dist_get(dest,i));
     }
     inform_dist_free(dest);
     inform_dist_free(source);
@@ -210,6 +211,7 @@ CTEST(Distribution, CopySameSize)
     for (size_t i = 0; i < inform_dist_size(source); ++i)
     {
         ASSERT_EQUAL(inform_dist_get(source,i), inform_dist_get(dest,i));
+        ASSERT_EQUAL(i+1, inform_dist_get(dest,i));
     }
     inform_dist_free(dest);
     inform_dist_free(source);
@@ -233,6 +235,7 @@ CTEST(Distribution, CopyResize)
     for (size_t i = 0; i < inform_dist_size(source); ++i)
     {
         ASSERT_EQUAL(inform_dist_get(source,i), inform_dist_get(dest,i));
+        ASSERT_EQUAL(i+1, inform_dist_get(dest,i));
     }
     inform_dist_free(dest);
     inform_dist_free(source);


### PR DESCRIPTION
The source and destination arguments to the `memcpy` function were swapped in `inform_dist_copy`. Tests were added to detect this, and the bug was fixed.