### PR TITLE
Extern definitions for compatibility with C++

### DIFF
--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -7,6 +7,11 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * A distribution of observed event frequencies
  *
@@ -225,3 +230,7 @@ double inform_dist_prob(inform_dist const *dist, uint64_t event);
  * @return a dynamically allocated array of the probabilities
  */
 double* inform_dist_dump(inform_dist const *dist);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/inform/entropy.h
+++ b/include/inform/entropy.h
@@ -6,6 +6,11 @@
 #include <inform/dist.h>
 #include <math.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /// an entropy is just a double
 typedef double entropy;
 
@@ -58,3 +63,7 @@ entropy inform_mutual_info(inform_dist const *joint,
 entropy inform_conditional_entropy(inform_dist const* joint,
         inform_dist const *marginal,
         double base);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/inform/error.h
+++ b/include/inform/error.h
@@ -6,6 +6,11 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * Determine whether or not a potential NaN tag is valid.
  *
@@ -46,3 +51,7 @@ double inform_nan(uint64_t tag);
  * @see inform_nan
  */
 uint64_t inform_nan_tag(double x);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/inform/state_encoding.h
+++ b/include/inform/state_encoding.h
@@ -6,6 +6,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #define INFORM_ENCODING_ERROR(n) (inform_encoding_error + n)
 static uint64_t const inform_encoding_error = 0x8000000000000000;
 
@@ -55,3 +60,8 @@ uint64_t inform_encode(uint64_t const *state, uint64_t n, uint64_t base);
  * @see inform_encode
  */
 uint64_t* inform_decode(uint64_t encoding, uint64_t n, uint64_t base);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/inform/time_series.h
+++ b/include/inform/time_series.h
@@ -5,6 +5,11 @@
 
 #include <inform/entropy.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * @brief Populate the active information distributions
  *
@@ -186,3 +191,7 @@ entropy inform_transfer_entropy(uint64_t const *series_y, uint64_t const *series
  * @return the transfer entropy of the ensemble
  */
 entropy inform_transfer_entropy_ensemble(uint64_t const *series_y, uint64_t const *series_x, size_t n, size_t m, uint64_t b, uint64_t k);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
When the headers are included in a C++ source, the declarations
will have C external linkage so as to ensure that the symbols
are properly resolved.