### PR TITLE
Update the copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016, ELIFE
+Copyright (c) 2016-2017, ELIFE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/include/inform/active_info.h
+++ b/include/inform/active_info.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/block_entropy.h
+++ b/include/inform/block_entropy.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/conditional_entropy.h
+++ b/include/inform/conditional_entropy.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/entropy_rate.h
+++ b/include/inform/entropy_rate.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/error.h
+++ b/include/inform/error.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/export.h
+++ b/include/inform/export.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/inform.h
+++ b/include/inform/inform.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/mutual_info.h
+++ b/include/inform/mutual_info.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/relative_entropy.h
+++ b/include/inform/relative_entropy.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/shannon.h
+++ b/include/inform/shannon.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/transfer_entropy.h
+++ b/include/inform/transfer_entropy.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/utilities.h
+++ b/include/inform/utilities.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/utilities/binning.h
+++ b/include/inform/utilities/binning.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/utilities/coalesce.h
+++ b/include/inform/utilities/coalesce.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/utilities/encoding.h
+++ b/include/inform/utilities/encoding.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/include/inform/utilities/random.h
+++ b/include/inform/utilities/random.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/src/active_info.c
+++ b/src/active_info.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/active_info.h>

--- a/src/block_entropy.c
+++ b/src/block_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/block_entropy.h>

--- a/src/conditional_entropy.c
+++ b/src/conditional_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/conditional_entropy.h>

--- a/src/dist.c
+++ b/src/dist.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/dist.h>

--- a/src/entropy_rate.c
+++ b/src/entropy_rate.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/entropy_rate.h>

--- a/src/error.c
+++ b/src/error.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/error.h>

--- a/src/mutual_info.c
+++ b/src/mutual_info.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/mutual_info.h>

--- a/src/relative_entropy.c
+++ b/src/relative_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/relative_entropy.h>

--- a/src/shannon.c
+++ b/src/shannon.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/shannon.h>

--- a/src/transfer_entropy.c
+++ b/src/transfer_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/shannon.h>

--- a/src/utilities/binning.c
+++ b/src/utilities/binning.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <assert.h>

--- a/src/utilities/coalesce.c
+++ b/src/utilities/coalesce.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/utilities/coalesce.h>

--- a/src/utilities/encoding.c
+++ b/src/utilities/encoding.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/utilities/encoding.h>

--- a/src/utilities/random.c
+++ b/src/utilities/random.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/utilities/random.h>

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Douglas Moore. All rights reserved.
+// Copyright 2016-2017 Douglas Moore. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/test/unittests/active_info.c
+++ b/test/unittests/active_info.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/block_entropy.c
+++ b/test/unittests/block_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/canary.c
+++ b/test/unittests/canary.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <unit.h>

--- a/test/unittests/conditional_entropy.c
+++ b/test/unittests/conditional_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <unit.h>

--- a/test/unittests/entropy_rate.c
+++ b/test/unittests/entropy_rate.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/main.c
+++ b/test/unittests/main.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <unit.h>

--- a/test/unittests/mutual_info.c
+++ b/test/unittests/mutual_info.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/relative_entropy.c
+++ b/test/unittests/relative_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/shannon.c
+++ b/test/unittests/shannon.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <unit.h>

--- a/test/unittests/transfer_entropy.c
+++ b/test/unittests/transfer_entropy.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/util.c
+++ b/test/unittests/util.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include "util.h"

--- a/test/unittests/util.h
+++ b/test/unittests/util.h
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #pragma once

--- a/test/unittests/utilities.c
+++ b/test/unittests/utilities.c
@@ -1,4 +1,4 @@
-// Copyright 2016 ELIFE. All rights reserved.
+// Copyright 2016-2017 ELIFE. All rights reserved.
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <float.h>


### PR DESCRIPTION
It is 2017. The copyright headers should reflect this. This commit
closes #29.