### PR TITLE
Switch all time series measures to base-2 logarithms

### DIFF
--- a/include/inform/conditional_entropy.h
+++ b/include/inform/conditional_entropy.h
@@ -15,14 +15,14 @@ extern "C"
  * first as the condition.
  */
 EXPORT double inform_conditional_entropy(int const *xs, int const *ys,
-    size_t n, int bx, int by, double b, inform_error *err);
+    size_t n, int bx, int by, inform_error *err);
 
 /**
  * Compute the local conditional entropy between two timeseries, using the
  * first as the condition.
  */
 EXPORT double *inform_local_conditional_entropy(int const *xs, int const *ys,
-    size_t n, int bx, int by, double b, double *mi, inform_error *err);
+    size_t n, int bx, int by, double *mi, inform_error *err);
 
 #ifdef __cplusplus
 }

--- a/include/inform/mutual_info.h
+++ b/include/inform/mutual_info.h
@@ -14,13 +14,13 @@ extern "C"
  * Compute the mutual information between two timeseries
  */
 EXPORT double inform_mutual_info(int const *xs, int const *ys, size_t n,
-    int bx, int by, double b, inform_error *err);
+    int bx, int by, inform_error *err);
 
 /**
  * Compute the local mutual information between two timeseries
  */
 EXPORT double *inform_local_mutual_info(int const *xs, int const *ys, size_t n,
-    int bx, int by, double b, double *mi, inform_error *err);
+    int bx, int by, double *mi, inform_error *err);
 
 #ifdef __cplusplus
 }

--- a/include/inform/relative_entropy.h
+++ b/include/inform/relative_entropy.h
@@ -15,14 +15,14 @@ extern "C"
  * a timeseries of samples from two distributions.
  */
 EXPORT double inform_relative_entropy(int const *xs, int const *ys, size_t n,
-    int b, double base, inform_error *err);
+    int b, inform_error *err);
 
 /**
  * Compute the pointwise relative entropy between two timeseries, each
  * considered as a timeseries of samples from two distributions.
  */
 EXPORT double *inform_local_relative_entropy(int const *xs, int const *ys,
-    size_t n, int b, double base, double *re, inform_error *err);
+    size_t n, int b, double *re, inform_error *err);
 
 #ifdef __cplusplus
 }

--- a/src/active_info.c
+++ b/src/active_info.c
@@ -122,7 +122,7 @@ double inform_active_info(int const *series, size_t n, size_t m, int b, size_t k
         accumulate_observations(series, m, b, k, &states, &histories, &futures);
     }
 
-    double ai = inform_shannon_mi(&states, &histories, &futures, (double) b);
+    double ai = inform_shannon_mi(&states, &histories, &futures, 2.0);
 
     free(data);
 
@@ -191,7 +191,7 @@ double *inform_local_active_info(int const *series, size_t n, size_t m,
     for (size_t i = 0; i < N; ++i)
     {
         ai[i] = inform_shannon_pmi(&states, &histories, &futures, state[i],
-            history[i], future[i], (double) b);
+            history[i], future[i], 2.0);
     }
 
     free(future);
@@ -297,7 +297,7 @@ double *inform_local_active_info2(int const *series, size_t n, size_t m,
 	for (size_t h = 0; h < n; ++h)
 	{
 	    ai[i+h*(m-k)] = inform_shannon_pmi(&states, &histories, &futures, state[h],
-                history[h], future[h], (double) b);
+                history[h], future[h], 2.0);
 	}
 	
 	memset(data, 0, total_size * sizeof(uint32_t));		

--- a/src/block_entropy.c
+++ b/src/block_entropy.c
@@ -110,7 +110,7 @@ double inform_block_entropy(int const *series, size_t n, size_t m, int b,
         accumulate_observations(series, m, b, k, &states);
     }
 
-    double be = inform_shannon(&states, (double) b);
+    double be = inform_shannon(&states, 2.0);
 
     free(data);
 
@@ -160,7 +160,7 @@ double *inform_local_block_entropy(int const *series, size_t n, size_t m, int b,
 
     for (size_t i = 0; i < N; ++i)
     {
-        be[i] = inform_shannon_si(&states, state[i], (double) b);
+        be[i] = inform_shannon_si(&states, state[i], 2.0);
     }
 
     free(state);

--- a/src/conditional_entropy.c
+++ b/src/conditional_entropy.c
@@ -76,7 +76,7 @@ inline static void free_all(inform_dist **x, inform_dist **xy)
 }
 
 double inform_conditional_entropy(int const *xs, int const *ys, size_t n,
-    int bx, int by, double b, inform_error *err)
+    int bx, int by, inform_error *err)
 {
     if (check_arguments(xs, ys, n, bx, by, err)) return NAN;
 
@@ -85,7 +85,7 @@ double inform_conditional_entropy(int const *xs, int const *ys, size_t n,
 
     accumulate(xs, ys, n, by, x, xy);
 
-    double ce = inform_shannon_ce(xy, x, (double) b);
+    double ce = inform_shannon_ce(xy, x, 2.0);
 
     free_all(&x, &xy);
 
@@ -93,7 +93,7 @@ double inform_conditional_entropy(int const *xs, int const *ys, size_t n,
 }
 
 double *inform_local_conditional_entropy(int const *xs, int const *ys,
-    size_t n, int bx, int by, double b, double *ce, inform_error *err)
+    size_t n, int bx, int by, double *ce, inform_error *err)
 {
     if (check_arguments(xs, ys, n, bx, by, err)) return NULL;
 
@@ -112,7 +112,7 @@ double *inform_local_conditional_entropy(int const *xs, int const *ys,
     for (size_t i = 0; i < n; ++i)
     {
         int z = xs[i]*by + ys[i];
-        ce[i] = inform_shannon_pce(xy, x, z, xs[i], (double) b);
+        ce[i] = inform_shannon_pce(xy, x, z, xs[i], 2.0);
     }
 
     free_all(&x, &xy);

--- a/src/entropy_rate.c
+++ b/src/entropy_rate.c
@@ -118,7 +118,7 @@ double inform_entropy_rate(int const *series, size_t n, size_t m, int b,
         accumulate_observations(series, m, b, k, &states, &histories);
     }
 
-    double er = inform_shannon_ce(&states, &histories, (double) b);
+    double er = inform_shannon_ce(&states, &histories, 2.0);
 
     free(data);
 
@@ -177,7 +177,7 @@ double *inform_local_entropy_rate(int const *series, size_t n, size_t m, int b,
 
     for (size_t i = 0; i < N; ++i)
     {
-        er[i] = inform_shannon_pce(&states, &histories, state[i], history[i], (double) b);
+        er[i] = inform_shannon_pce(&states, &histories, state[i], history[i], 2.0);
     }
 
     free(history);

--- a/src/mutual_info.c
+++ b/src/mutual_info.c
@@ -85,7 +85,7 @@ inline static void free_all(inform_dist **x, inform_dist **y, inform_dist **xy)
 }
 
 double inform_mutual_info(int const *xs, int const *ys, size_t n, int bx,
-    int by, double b, inform_error *err)
+    int by, inform_error *err)
 {
     if (check_arguments(xs, ys, n, bx, by, err)) return NAN;
 
@@ -94,7 +94,7 @@ double inform_mutual_info(int const *xs, int const *ys, size_t n, int bx,
 
     accumulate(xs, ys, n, by, x, y, xy);
 
-    double mi = inform_shannon_mi(xy, x, y, (double) b);
+    double mi = inform_shannon_mi(xy, x, y, 2.0);
 
     free_all(&x, &y, &xy);
 
@@ -102,7 +102,7 @@ double inform_mutual_info(int const *xs, int const *ys, size_t n, int bx,
 }
 
 double *inform_local_mutual_info(int const *xs, int const *ys, size_t n, int bx,
-    int by, double b, double *mi, inform_error *err)
+    int by, double *mi, inform_error *err)
 {
     if (check_arguments(xs, ys, n, bx, by, err)) return NULL;
 
@@ -121,7 +121,7 @@ double *inform_local_mutual_info(int const *xs, int const *ys, size_t n, int bx,
     for (size_t i = 0; i < n; ++i)
     {
         int z = xs[i]*by + ys[i];
-        mi[i] = inform_shannon_pmi(xy, x, y, z, xs[i], ys[i], (double) b);
+        mi[i] = inform_shannon_pmi(xy, x, y, z, xs[i], ys[i], 2.0);
     }
 
     free_all(&x, &y, &xy);

--- a/src/relative_entropy.c
+++ b/src/relative_entropy.c
@@ -72,7 +72,7 @@ inline static void free_all(inform_dist **x, inform_dist **y)
 }
 
 double inform_relative_entropy(int const *xs, int const *ys, size_t n, int b,
-    double base, inform_error *err)
+    inform_error *err)
 {
     if (check_arguments(xs, ys, n, b, err)) return NAN;
 
@@ -81,7 +81,7 @@ double inform_relative_entropy(int const *xs, int const *ys, size_t n, int b,
 
     accumulate(xs, ys, n, x, y);
 
-    double re = inform_shannon_re(x, y, base);
+    double re = inform_shannon_re(x, y, 2.0);
 
     free_all(&x, &y);
 
@@ -89,7 +89,7 @@ double inform_relative_entropy(int const *xs, int const *ys, size_t n, int b,
 }
 
 double *inform_local_relative_entropy(int const *xs, int const *ys, size_t n,
-    int b, double base, double *re, inform_error *err)
+    int b, double *re, inform_error *err)
 {
     if (check_arguments(xs, ys, n, b, err)) return NULL;
 
@@ -107,7 +107,7 @@ double *inform_local_relative_entropy(int const *xs, int const *ys, size_t n,
 
     for (size_t i = 0; i < (size_t) b; ++i)
     {
-        re[i] = inform_shannon_pre(x, y, i, base);
+        re[i] = inform_shannon_pre(x, y, i, 2.0);
     }
 
     free_all(&x, &y);

--- a/src/transfer_entropy.c
+++ b/src/transfer_entropy.c
@@ -143,10 +143,10 @@ double inform_transfer_entropy(int const *node_y, int const *node_x, size_t n,
         accumulate_observations(node_y, node_x, m, b, k, &states, &histories, &sources, &predicates);
     }
 
-    double te = inform_shannon(&sources, (double) b) +
-        inform_shannon(&predicates, (double) b) -
-        inform_shannon(&states, (double) b) -
-        inform_shannon(&histories, (double) b);
+    double te = inform_shannon(&sources, 2.0) +
+        inform_shannon(&predicates, 2.0) -
+        inform_shannon(&states, 2.0) -
+        inform_shannon(&histories, 2.0);
 
     free(data);
 
@@ -226,7 +226,7 @@ double *inform_local_transfer_entropy(int const *node_y, int const *node_x,
     for (size_t i = 0; i < N; ++i)
     {
         te[i] = inform_shannon_pcmi(&states, &sources, &predicates, &histories,
-            state[i], source[i], predicate[i], history[i], (double) b);
+            state[i], source[i], predicate[i], history[i], 2.0);
     }
 
     free(predicate);
@@ -352,7 +352,7 @@ double *inform_local_transfer_entropy2(int const *node_y, int const *node_x,
 	{
 	    te[i+h*(m-k)] = inform_shannon_pcmi(&states, &sources, &predicates, &histories,
 						state[h], source[h], predicate[h], history[h],
-						(double) b);
+						2.0);
 	}
 	
 	memset(data, 0, total_size * sizeof(uint32_t));		

--- a/test/unittests/active_info.c
+++ b/test/unittests/active_info.c
@@ -135,15 +135,15 @@ UNIT(ActiveInfoSingleSeries_Base2)
 
 UNIT(ActiveInfoSingleSeries_Base4)
 {
-    ASSERT_DBL_NEAR_TOL(0.635471,
+    ASSERT_DBL_NEAR_TOL(1.270942,
             inform_active_info((int[]){3,3,3,2,1,0,0,0,1}, 1, 9, 4, 2, NULL),
             1e-6);
 
-    ASSERT_DBL_NEAR_TOL(0.635471,
+    ASSERT_DBL_NEAR_TOL(1.270942,
             inform_active_info((int[]){2,2,3,3,3,3,2,1,0}, 1, 9, 4, 2, NULL),
             1e-6);
 
-    ASSERT_DBL_NEAR_TOL(0.234783,
+    ASSERT_DBL_NEAR_TOL(0.469566,
             inform_active_info((int[]){2,2,2,2,2,2,1,1,1}, 1, 9, 4, 2, NULL),
             1e-6);
 }
@@ -187,7 +187,7 @@ UNIT(ActiveInfoEnsemble_Base4)
             0, 0, 0, 0, 1, 1, 0, 0, 0,
             1, 1, 0, 0, 0, 1, 1, 2, 2,
         };
-        ASSERT_DBL_NEAR_TOL(0.662146,
+        ASSERT_DBL_NEAR_TOL(1.324292,
                 inform_active_info(series, 4, 9, 4, 2, NULL),
                 1e-6);
     }
@@ -331,13 +331,13 @@ UNIT(LocalActiveInfoSingleSeries_Base4)
 {
     double ai[7];
     ASSERT_NOT_NULL(inform_local_active_info((int[]){3,3,3,2,1,0,0,0,1}, 1, 9, 4, 2, ai, NULL));
-    ASSERT_DBL_NEAR_TOL(0.635471, AVERAGE(ai), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.270942, AVERAGE(ai), 1e-6);
 
     ASSERT_NOT_NULL(inform_local_active_info((int[]){2,2,3,3,3,3,2,1,0}, 1, 9, 4, 2, ai, NULL));
-    ASSERT_DBL_NEAR_TOL(0.635471, AVERAGE(ai), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.270942, AVERAGE(ai), 1e-6);
 
     ASSERT_NOT_NULL(inform_local_active_info((int[]){2,2,2,2,2,2,1,1,1}, 1, 9, 4, 2, ai, NULL));
-    ASSERT_DBL_NEAR_TOL(0.234783, AVERAGE(ai), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.469566, AVERAGE(ai), 1e-6);
 }
 
 UNIT(LocalActiveInfoEnsemble)
@@ -411,7 +411,7 @@ UNIT(LocalActiveInfoEnsemble_Base4)
             1, 1, 0, 0, 0, 1, 1, 2, 2,
         };
         ASSERT_NOT_NULL(inform_local_active_info(series, 4, 9, 4, 2, ai, NULL));
-        ASSERT_DBL_NEAR_TOL(0.662146, AVERAGE(ai), 1e-6);
+        ASSERT_DBL_NEAR_TOL(1.324292, AVERAGE(ai), 1e-6);
     }
 }
 

--- a/test/unittests/block_entropy.c
+++ b/test/unittests/block_entropy.c
@@ -135,15 +135,15 @@ UNIT(BlockEntropySingleSeries_Base2)
 
 UNIT(BlockEntropySingleSeries_Base4)
 {
-    ASSERT_DBL_NEAR_TOL(1.250000,
+    ASSERT_DBL_NEAR_TOL(2.50000,
             inform_block_entropy((int[]){3,3,3,2,1,0,0,0,1}, 1, 9, 4, 2, NULL),
             1e-6);
 
-    ASSERT_DBL_NEAR_TOL(1.202820,
+    ASSERT_DBL_NEAR_TOL(2.40564,
             inform_block_entropy((int[]){2,2,3,3,3,3,2,1,0}, 1, 9, 4, 2, NULL),
             1e-6);
 
-    ASSERT_DBL_NEAR_TOL(0.649397,
+    ASSERT_DBL_NEAR_TOL(1.298794,
             inform_block_entropy((int[]){2,2,2,2,2,2,1,1,1}, 1, 9, 4, 2, NULL),
             1e-6);
 }
@@ -187,7 +187,7 @@ UNIT(BlockEntropyEnsemble_Base4)
             0, 0, 0, 0, 1, 1, 0, 0, 0,
             1, 1, 0, 0, 0, 1, 1, 2, 2,
         };
-        ASSERT_DBL_NEAR_TOL(1.505488,
+        ASSERT_DBL_NEAR_TOL(3.010976,
                 inform_block_entropy(series, 4, 9, 4, 2, NULL),
                 1e-6);
     }
@@ -331,13 +331,13 @@ UNIT(LocalBlockEntropySingleSeries_Base4)
 {
     double be[8];
     ASSERT_NOT_NULL(inform_local_block_entropy((int[]){3,3,3,2,1,0,0,0,1}, 1, 9, 4, 2, be, NULL));
-    ASSERT_DBL_NEAR_TOL(1.250000, AVERAGE(be), 1e-6);
+    ASSERT_DBL_NEAR_TOL(2.5, AVERAGE(be), 1e-6);
 
     ASSERT_NOT_NULL(inform_local_block_entropy((int[]){2,2,3,3,3,3,2,1,0}, 1, 9, 4, 2, be, NULL));
-    ASSERT_DBL_NEAR_TOL(1.202820, AVERAGE(be), 1e-6);
+    ASSERT_DBL_NEAR_TOL(2.40564, AVERAGE(be), 1e-6);
 
     ASSERT_NOT_NULL(inform_local_block_entropy((int[]){2,2,2,2,2,2,1,1,1}, 1, 9, 4, 2, be, NULL));
-    ASSERT_DBL_NEAR_TOL(0.649397, AVERAGE(be), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.298794, AVERAGE(be), 1e-6);
 }
 
 UNIT(LocalBlockEntropyEnsemble)
@@ -381,7 +381,7 @@ UNIT(LocalBlockEntropyEnsemble_Base4)
             1, 1, 0, 0, 0, 1, 1, 2, 2,
         };
         ASSERT_NOT_NULL(inform_local_block_entropy(series, 4, 9, 4, 2, be, NULL));
-        ASSERT_DBL_NEAR_TOL(1.505488, AVERAGE(be), 1e-6);
+        ASSERT_DBL_NEAR_TOL(3.010976, AVERAGE(be), 1e-6);
     }
 }
 

--- a/test/unittests/conditional_entropy.c
+++ b/test/unittests/conditional_entropy.c
@@ -9,12 +9,12 @@
 UNIT(ConditionalEntropyNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(NULL, NULL, 3, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy(NULL, NULL, 3, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy((int[]){0,0,1}, NULL, 3, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy((int[]){0,0,1}, NULL, 3, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -23,7 +23,7 @@ UNIT(ConditionalEntropySeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 0, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 0, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -35,12 +35,12 @@ UNIT(ConditionalEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 8, i, 2, 2, &err)));
+        ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 8, i, 2, &err)));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
 
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 8, 2, i, 2, &err)));
+        ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 8, 2, i, &err)));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -51,12 +51,12 @@ UNIT(ConditionalEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(ys, xs, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy(ys, xs, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -66,12 +66,12 @@ UNIT(ConditionalEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -81,56 +81,56 @@ UNIT(ConditionalEntropy)
     inform_error err = INFORM_SUCCESS;
 
     ASSERT_DBL_NEAR_TOL(0.899985, inform_conditional_entropy((int[]){0,0,1,1,1,1,0,0,0},
-        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.972765, inform_conditional_entropy((int[]){1,0,0,1,0,0,1,0,0},
-        (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_conditional_entropy((int[]){0,0,0,0,1,1,1,1},
-        (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_conditional_entropy((int[]){0,0,1,1,1,1,0,0,0},
-        (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.918296, inform_conditional_entropy((int[]){1,1,0,1,0,1,1,1,0},
-        (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.918296, inform_conditional_entropy((int[]){0,0,0,0,0,0,0,0,0},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.845516, inform_conditional_entropy((int[]){1,1,1,1,0,0,0,0,1},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.899985, inform_conditional_entropy((int[]){1,1,0,0,1,1,0,0,1},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_conditional_entropy((int[]){0,1,0,1,0,1,0,1},
-        (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, 2, &err), 1e-6);
+        (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.918296,
         inform_conditional_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1},
-            (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, 2, &err), 1e-6);
+            (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.444444, inform_conditional_entropy((int[]){0,0,1,1,2,1,1,0,0},
-        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, 2, &err), 1e-6);
+        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.666667, inform_conditional_entropy((int[]){0,1,0,0,1,0,0,1,0},
-        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.606844, inform_conditional_entropy((int[]){1,0,0,1,0,0,1,0},
-        (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, 2, &err), 1e-6);
+        (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }
 
@@ -138,12 +138,12 @@ UNIT(LocalConditionalEntropyNULLSeries)
 {
     double ce[8];
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy(NULL, NULL, 3, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy(NULL, NULL, 3, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy((int[]){0,0,1}, NULL, 3, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy((int[]){0,0,1}, NULL, 3, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -153,7 +153,7 @@ UNIT(LocalConditionalEntropySeriesTooShort)
     double ce[8];
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy(xs, xs, 0, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy(xs, xs, 0, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -166,12 +166,12 @@ UNIT(LocalConditionalEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_NULL(inform_local_conditional_entropy(xs, xs, 8, i, 2, 2, ce, &err));
+        ASSERT_NULL(inform_local_conditional_entropy(xs, xs, 8, i, 2, ce, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
 
         err = INFORM_SUCCESS;
-        ASSERT_NULL(inform_local_conditional_entropy(xs, xs, 8, 2, i, 2, ce, &err));
+        ASSERT_NULL(inform_local_conditional_entropy(xs, xs, 8, 2, i, ce, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -183,12 +183,12 @@ UNIT(LocalConditionalEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy(xs, ys, 8, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy(xs, ys, 8, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy(ys, xs, 8, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy(ys, xs, 8, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -199,12 +199,12 @@ UNIT(LocalConditionalEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy(xs, ys, 8, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy(xs, ys, 8, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_conditional_entropy(xs, ys, 8, 2, 2, 2, ce, &err));
+    ASSERT_NULL(inform_local_conditional_entropy(xs, ys, 8, 2, 2, ce, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -214,7 +214,7 @@ UNIT(LocalConditionalEntropyAllocatesOutput)
     int const xs[] = {0,0,1,1,1,1,0,0,0};
     int const ys[] = {1,1,0,0,0,0,1,1,1};
     inform_error err = INFORM_SUCCESS;
-    double *ce = inform_local_conditional_entropy(xs, ys, 9, 2, 2, 2, NULL, &err);
+    double *ce = inform_local_conditional_entropy(xs, ys, 9, 2, 2, NULL, &err);
     ASSERT_NOT_NULL(ce);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
     free(ce);
@@ -227,55 +227,55 @@ UNIT(LocalConditionalEntropy)
     double ce_9[9];
     double ce_12[12];
 
-    inform_local_conditional_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.899985, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){1,0,0,1,0,0,1,0,0}, (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){1,0,0,1,0,0,1,0,0}, (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.972765, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, 2, ce_8, &err);
+    inform_local_conditional_entropy((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, ce_8, &err);
     ASSERT_DBL_NEAR_TOL(0.000000, AVERAGE(ce_8), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.000000, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.918296, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.918296, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.845516, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.899985, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, 2, ce_8, &err);
+    inform_local_conditional_entropy((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, ce_8, &err);
     ASSERT_DBL_NEAR_TOL(0.000000, AVERAGE(ce_8), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, 2, ce_12, &err);
+    inform_local_conditional_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, ce_12, &err);
     ASSERT_DBL_NEAR_TOL(0.918296, AVERAGE(ce_12), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.444444, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
     
-    inform_local_conditional_entropy((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, 2, ce_9, &err);
+    inform_local_conditional_entropy((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, ce_9, &err);
     ASSERT_DBL_NEAR_TOL(0.666667, AVERAGE(ce_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_conditional_entropy((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, 2, ce_8, &err);
+    inform_local_conditional_entropy((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, ce_8, &err);
     ASSERT_DBL_NEAR_TOL(0.606844, AVERAGE(ce_8), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }

--- a/test/unittests/entropy_rate.c
+++ b/test/unittests/entropy_rate.c
@@ -137,15 +137,15 @@ UNIT(EntropyRateSingleSeries_Base2)
 
 UNIT(EntropyRateSingleSeries_Base4)
 {
-    ASSERT_DBL_NEAR_TOL(0.285715,
+    ASSERT_DBL_NEAR_TOL(0.571428,
             inform_entropy_rate((int[]){3,3,3,2,1,0,0,0,1}, 1, 9, 4, 2, NULL),
             1e-6);
 
-    ASSERT_DBL_NEAR_TOL(0.196778,
+    ASSERT_DBL_NEAR_TOL(0.393556,
             inform_entropy_rate((int[]){2,2,3,3,3,3,2,1,0}, 1, 9, 4, 2, NULL),
             1e-6);
 
-    ASSERT_DBL_NEAR_TOL(0.257831,
+    ASSERT_DBL_NEAR_TOL(0.515662,
             inform_entropy_rate((int[]){2,2,2,2,2,2,1,1,1}, 1, 9, 4, 2, NULL),
             1e-6);
 }
@@ -189,7 +189,7 @@ UNIT(EntropyRateEnsemble_Base4)
             0, 0, 0, 0, 1, 1, 0, 0, 0,
             1, 1, 0, 0, 0, 1, 1, 2, 2,
         };
-        ASSERT_DBL_NEAR_TOL(0.272234,
+        ASSERT_DBL_NEAR_TOL(0.544468,
                 inform_entropy_rate(series, 4, 9, 4, 2, NULL),
                 1e-6);
     }
@@ -334,13 +334,13 @@ UNIT(LocalEntropyRateSingleSeries_Base4)
     double er[7];
 
     ASSERT_NOT_NULL(inform_local_entropy_rate((int[]){3,3,3,2,1,0,0,0,1}, 1, 9, 4, 2, er, NULL));
-    ASSERT_DBL_NEAR_TOL(0.285715, AVERAGE(er), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.571428, AVERAGE(er), 1e-6);
 
     ASSERT_NOT_NULL(inform_local_entropy_rate((int[]){2,2,3,3,3,3,2,1,0}, 1, 9, 4, 2, er, NULL));
-    ASSERT_DBL_NEAR_TOL(0.196778, AVERAGE(er), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.393556, AVERAGE(er), 1e-6);
 
     ASSERT_NOT_NULL(inform_local_entropy_rate((int[]){2,2,2,2,2,2,1,1,1}, 1, 9, 4, 2, er, NULL));
-    ASSERT_DBL_NEAR_TOL(0.257831, AVERAGE(er), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.515662, AVERAGE(er), 1e-6);
 }
 
 UNIT(LocalEntropyRateEnsemble)
@@ -384,7 +384,7 @@ UNIT(LocalEntropyRateEnsemble_Base4)
             1, 1, 0, 0, 0, 1, 1, 2, 2,
         };
         ASSERT_NOT_NULL(inform_local_entropy_rate(series, 4, 9, 4, 2, er, NULL));
-        ASSERT_DBL_NEAR_TOL(0.272234, AVERAGE(er), 1e-6);
+        ASSERT_DBL_NEAR_TOL(0.544468, AVERAGE(er), 1e-6);
     }
 }
 

--- a/test/unittests/mutual_info.c
+++ b/test/unittests/mutual_info.c
@@ -9,12 +9,12 @@
 UNIT(MutualInfoNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(NULL, NULL, 3, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info(NULL, NULL, 3, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info((int[]){0,0,1}, NULL, 3, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info((int[]){0,0,1}, NULL, 3, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -23,7 +23,7 @@ UNIT(MutualInfoSeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(xs, xs, 0, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info(xs, xs, 0, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -35,12 +35,12 @@ UNIT(MutualInfoInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, xs, 8, i, 2, 2, &err)));
+        ASSERT_TRUE(isnan(inform_mutual_info(xs, xs, 8, i, 2, &err)));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
 
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, xs, 8, 2, i, 2, &err)));
+        ASSERT_TRUE(isnan(inform_mutual_info(xs, xs, 8, 2, i, &err)));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -51,12 +51,12 @@ UNIT(MutualInfoNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(xs, ys, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info(xs, ys, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(ys, xs, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info(ys, xs, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -66,12 +66,12 @@ UNIT(MutualInfoBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(xs, ys, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info(xs, ys, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(xs, ys, 8, 2, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_mutual_info(xs, ys, 8, 2, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -80,48 +80,48 @@ UNIT(MutualInfo)
 {
     inform_error err = INFORM_SUCCESS;
     ASSERT_DBL_NEAR_TOL(1.000000, inform_mutual_info((int[]){0,0,0,0,1,1,1,1},
-        (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.991076, inform_mutual_info((int[]){0,0,1,1,1,1,0,0,0},
-        (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.072780, inform_mutual_info((int[]){1,1,0,1,0,1,1,1,0},
-        (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_mutual_info((int[]){0,0,0,0,0,0,0,0,0},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.072780, inform_mutual_info((int[]){1,1,1,1,0,0,0,0,1},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.018311, inform_mutual_info((int[]){1,1,0,0,1,1,0,0,1},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(1.000000, inform_mutual_info((int[]){0,1,0,1,0,1,0,1},
-        (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, 2, &err), 1e-6);
+        (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.666667,
         inform_mutual_info((int[]){0,0,0,0,0,0,1,1,1,1,1,1},
-            (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, 2, &err), 1e-6);
+            (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.473851, inform_mutual_info((int[]){0,0,1,1,2,1,1,0,0},
-        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, 2, &err), 1e-6);
+        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.251629, inform_mutual_info((int[]){0,1,0,0,1,0,0,1,0},
-        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, 2, &err), 1e-6);
+        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.954434, inform_mutual_info((int[]){1,0,0,1,0,0,1,0},
-        (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, 2, &err), 1e-6);
+        (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }
 
@@ -129,12 +129,12 @@ UNIT(LocalMutualInfoNULLSeries)
 {
     double mi[8];
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info(NULL, NULL, 3, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info(NULL, NULL, 3, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info((int[]){0,0,1}, NULL, 3, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info((int[]){0,0,1}, NULL, 3, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -144,7 +144,7 @@ UNIT(LocalMutualInfoSeriesTooShort)
     double mi[8];
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info(xs, xs, 0, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info(xs, xs, 0, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -157,12 +157,12 @@ UNIT(LocalMutualInfoInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_NULL(inform_local_mutual_info(xs, xs, 8, i, 2, 2, mi, &err));
+        ASSERT_NULL(inform_local_mutual_info(xs, xs, 8, i, 2, mi, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
 
         err = INFORM_SUCCESS;
-        ASSERT_NULL(inform_local_mutual_info(xs, xs, 8, 2, i, 2, mi, &err));
+        ASSERT_NULL(inform_local_mutual_info(xs, xs, 8, 2, i, mi, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -174,12 +174,12 @@ UNIT(LocalMutualInfoNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info(xs, ys, 8, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info(xs, ys, 8, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info(ys, xs, 8, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info(ys, xs, 8, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -190,12 +190,12 @@ UNIT(LocalMutualInfoBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info(xs, ys, 8, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info(xs, ys, 8, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_mutual_info(xs, ys, 8, 2, 2, 2, mi, &err));
+    ASSERT_NULL(inform_local_mutual_info(xs, ys, 8, 2, 2, mi, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -205,7 +205,7 @@ UNIT(LocalMutualInfoAllocatesOutput)
     int const xs[] = {0,0,1,1,1,1,0,0,0};
     int const ys[] = {1,1,0,0,0,0,1,1,1};
     inform_error err = INFORM_SUCCESS;
-    double *mi = inform_local_mutual_info(xs, ys, 9, 2, 2, 2, NULL, &err);
+    double *mi = inform_local_mutual_info(xs, ys, 9, 2, 2, NULL, &err);
     ASSERT_NOT_NULL(mi);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
     free(mi);
@@ -218,47 +218,47 @@ UNIT(LocalMutualInfo)
     double mi_9[9];
     double mi_12[12];
 
-    inform_local_mutual_info((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, 2, mi_8, &err);
+    inform_local_mutual_info((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, mi_8, &err);
     ASSERT_DBL_NEAR_TOL(1.000000, AVERAGE(mi_8), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.991076, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.072780, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.000000, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.072780, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.018311, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, 2, mi_8, &err);
+    inform_local_mutual_info((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 2, 3, mi_8, &err);
     ASSERT_DBL_NEAR_TOL(1.000000, AVERAGE(mi_8), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, 2, mi_12, &err);
+    inform_local_mutual_info((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 2, 3, mi_12, &err);
     ASSERT_DBL_NEAR_TOL(0.666667, AVERAGE(mi_12), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.473851, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
     
-    inform_local_mutual_info((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, 2, mi_9, &err);
+    inform_local_mutual_info((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, mi_9, &err);
     ASSERT_DBL_NEAR_TOL(0.251629, AVERAGE(mi_9), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_mutual_info((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, 2, mi_8, &err);
+    inform_local_mutual_info((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 2, 3, mi_8, &err);
     ASSERT_DBL_NEAR_TOL(0.954434, AVERAGE(mi_8), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }

--- a/test/unittests/relative_entropy.c
+++ b/test/unittests/relative_entropy.c
@@ -9,12 +9,12 @@
 UNIT(RelativeEntropyNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(NULL, NULL, 3, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy(NULL, NULL, 3, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,0,1}, NULL, 3, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,0,1}, NULL, 3, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -23,7 +23,7 @@ UNIT(RelativeEntropySeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, xs, 0, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy(xs, xs, 0, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -35,7 +35,7 @@ UNIT(RelativeEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_relative_entropy(xs, xs, 8, i, 2, &err)));
+        ASSERT_TRUE(isnan(inform_relative_entropy(xs, xs, 8, i, &err)));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -46,12 +46,12 @@ UNIT(RelativeEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(ys, xs, 8, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy(ys, xs, 8, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -61,12 +61,12 @@ UNIT(RelativeEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, 2, &err)));
+    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, &err)));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -76,56 +76,56 @@ UNIT(RelativeEntropy)
     inform_error err = INFORM_SUCCESS;
 
     ASSERT_DBL_NEAR_TOL(0.038330, inform_relative_entropy((int[]){0,0,1,1,1,1,0,0,0},
-        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.037010, inform_relative_entropy((int[]){1,0,0,1,0,0,1,0,0},
-        (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, 2, &err), 1e-6);
+        (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_relative_entropy((int[]){0,0,0,0,1,1,1,1},
-        (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,1,0,0,0,0}, 8, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.035770, inform_relative_entropy((int[]){0,0,1,1,1,1,0,0,0},
-        (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.037010, inform_relative_entropy((int[]){1,1,0,1,0,1,1,1,0},
-        (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(1.584963, inform_relative_entropy((int[]){0,0,0,0,0,0,0,0,0},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.038331, inform_relative_entropy((int[]){1,1,1,1,0,0,0,0,1},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.038331, inform_relative_entropy((int[]){1,1,0,0,1,1,0,0,1},
-        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,1,0,1,0,1,0,1},
-        (int[]){0,2,0,2,0,2,0,2}, 8, 3, 2, &err)));
+        (int[]){0,2,0,2,0,2,0,2}, 8, 3, &err)));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.584963,
         inform_relative_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1},
-            (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, 2, &err), 1e-6);
+            (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,0,1,1,2,1,1,0,0},
-        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, &err)));
+        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, &err)));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_relative_entropy((int[]){0,1,0,0,1,0,0,1,0},
-        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, &err), 1e-6);
+        (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.679964, inform_relative_entropy((int[]){1,0,0,1,0,0,1,0},
-        (int[]){2,0,1,2,0,1,2,0}, 8, 3, 2, &err), 1e-6);
+        (int[]){2,0,1,2,0,1,2,0}, 8, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }
 
@@ -133,12 +133,12 @@ UNIT(LocalRelativeEntropyNULLSeries)
 {
     double re[8];
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy(NULL, NULL, 3, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy(NULL, NULL, 3, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy((int[]){0,0,1}, NULL, 3, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy((int[]){0,0,1}, NULL, 3, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -148,7 +148,7 @@ UNIT(LocalRelativeEntropySeriesTooShort)
     double re[8];
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy(xs, xs, 0, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy(xs, xs, 0, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -161,7 +161,7 @@ UNIT(LocalRelativeEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_NULL(inform_local_relative_entropy(xs, xs, 8, i, 2, re, &err));
+        ASSERT_NULL(inform_local_relative_entropy(xs, xs, 8, i, re, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -173,12 +173,12 @@ UNIT(LocalRelativeEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy(xs, ys, 8, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy(xs, ys, 8, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy(ys, xs, 8, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy(ys, xs, 8, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -189,12 +189,12 @@ UNIT(LocalRelativeEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy(xs, ys, 8, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy(xs, ys, 8, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_NULL(inform_local_relative_entropy(xs, ys, 8, 2, 2, re, &err));
+    ASSERT_NULL(inform_local_relative_entropy(xs, ys, 8, 2, re, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -204,7 +204,7 @@ UNIT(LocalRelativeEntropyAllocatesOutput)
     int const xs[] = {0,0,1,1,1,1,0,0,0};
     int const ys[] = {1,1,0,0,0,0,1,1,1};
     inform_error err = INFORM_SUCCESS;
-    double *re = inform_local_relative_entropy(xs, ys, 9, 2, 2, NULL, &err);
+    double *re = inform_local_relative_entropy(xs, ys, 9, 2, NULL, &err);
     ASSERT_NOT_NULL(re);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
     free(re);
@@ -244,55 +244,55 @@ UNIT(LocalRelativeEntropy)
     double re_2[2];
     double re_3[3];
 
-    inform_local_relative_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){-0.263034, 0.415037}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){1,0,0,1,0,0,1,0,0}, (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){1,0,0,1,0,0,1,0,0}, (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.263034, -0.415037}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.000000, 0.000000}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.321928, -0.321928}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){-0.415037, 0.263034}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){1.584963, -INFINITY}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.415037, -0.263034}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.415037, -0.263034}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 3, 2, re_3, &err);
+    inform_local_relative_entropy((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 3, re_3, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.000000, INFINITY, -INFINITY}, re_3, 3, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, 2, re_3, &err);
+    inform_local_relative_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, re_3, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.584963, 0.584963, -INFINITY}, re_3, 3, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, 2, re_3, &err);
+    inform_local_relative_entropy((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, re_3, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){-0.584963, 0.415037, INFINITY}, re_3, 3, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, 2, re_2, &err);
+    inform_local_relative_entropy((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, re_2, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.000000, 0.000000, -INFINITY}, re_2, 2, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    inform_local_relative_entropy((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 3, 2, re_3, &err);
+    inform_local_relative_entropy((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 3, re_3, &err);
     ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.736966, 0.584963, -INFINITY}, re_3, 3, 1e-6));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }


### PR DESCRIPTION
The `b` argument to the time series measures conflates the meaning of the base: it is both the base of the time series and the base of the logarithm. The argument now only specifies the base of the time series; the logarithms are now base-2.