### PR TITLE
Implement the transition probability function

### DIFF
--- a/include/inform/error.h
+++ b/include/inform/error.h
@@ -33,6 +33,7 @@ typedef enum
     INFORM_EDIST        = 12, /// invalid distribution
     INFORM_EBIN         = 13, /// invalid binning
     INFORM_EENCODE      = 14, /// cannot encode state
+    INFORM_ETPMROW      = 15, /// all zero row in transition probability matrix
 } inform_error;
 
 /// set an error as pointed to by ERR

--- a/include/inform/utilities.h
+++ b/include/inform/utilities.h
@@ -7,3 +7,4 @@
 #include <inform/utilities/coalesce.h>
 #include <inform/utilities/encoding.h>
 #include <inform/utilities/random.h>
+#include <inform/utilities/tpm.h>

--- a/include/inform/utilities/tpm.h
+++ b/include/inform/utilities/tpm.h
@@ -1,0 +1,32 @@
+// Copyright 2016-2017 ELIFE. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+#pragma once
+
+#include <inform/error.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Compute the a transition probability matrix from a time series.
+ *
+ * The function allocates a tpm of the proper size if the *tpm* argument is
+ * `NULL`.
+ *
+ * @param[in] series  the timeseries
+ * @param[in] n       the number of initial conditions
+ * @param[in] m       the number of time steps for each initial condition
+ * @param[in] b       the base of the time series
+ * @param[in,out] tpm the transition probability matrix (or NULL)
+ * @param[out] err    an error code
+ * @return the transition probability matrix
+ */
+EXPORT double *inform_tpm(int const *series, size_t n, size_t m, int b,
+    double *tpm, inform_error *err);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,4 +13,5 @@ set(${PROJECT_NAME}_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/coalesce.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/encoding.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/random.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/utilities/tpm.c
     PARENT_SCOPE)

--- a/src/error.c
+++ b/src/error.c
@@ -37,6 +37,7 @@ char const *inform_strerror(inform_error const *err)
         case INFORM_EDIST:        return "invalid distribution encountered";
         case INFORM_EBIN:         return "invalid binning";
         case INFORM_EENCODE:      return "encoding/decoding failed";
+        case INFORM_ETPMROW:      return "all zero row in TPM";
         default:                  return "unrecognized error";
     }
 }

--- a/src/utilities/tpm.c
+++ b/src/utilities/tpm.c
@@ -1,0 +1,87 @@
+// Copyright 2016-2017 ELIFE. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+#include <inform/error.h>
+
+inline static bool check_arguments(int const *series, size_t n, size_t m, int b, 
+    inform_error *err)
+{
+    if (series == NULL)
+        INFORM_ERROR_RETURN(err, INFORM_ETIMESERIES, true);
+    else if (n == 0)
+        INFORM_ERROR_RETURN(err, INFORM_ENOINITS, true);
+    else if (m <= 1)
+        INFORM_ERROR_RETURN(err, INFORM_ESHORTSERIES, true);
+    else if (b < 2)
+        INFORM_ERROR_RETURN(err, INFORM_EBIN, true);
+    for (size_t i = 0; i < n * m; ++i)
+    {
+        if (series[i] < 0)
+            INFORM_ERROR_RETURN(err, INFORM_ENEGSTATE, true);
+        else if (b <= series[i])
+            INFORM_ERROR_RETURN(err, INFORM_EBADSTATE, true);
+    }
+    return false;
+}
+
+inline static double *setup_tpm(double *tpm, int b, inform_error *err)
+{
+    if (tpm == NULL)
+    {
+        tpm = calloc(b * b, sizeof(double));
+        if (tpm == NULL)
+        {
+            INFORM_ERROR_RETURN(err, INFORM_ENOMEM, NULL);
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < (size_t)(b * b); ++i)
+        {
+            tpm[i] = 0.0;
+        }
+    }
+    return tpm;
+}
+
+double *inform_tpm(int const *series, size_t n, size_t m, int b, double *tpm,
+    inform_error *err)
+{
+    if (check_arguments(series, n, m, b, err))
+        return NULL;
+
+    if ((tpm = setup_tpm(tpm, b, err)) == NULL)
+        return NULL;
+
+    int current = 0, future = 0;
+    for (size_t i = 0; i < n; ++i)
+    {
+        for (size_t j = 0; j < m - 1; ++j)
+        {
+            current = series[m * i + j];
+            future = series[m * i + j + 1];
+            tpm[b * current + future] += 1;
+        }
+    }
+
+    for (int i = 0; i < b; ++i)
+    {
+        double sum = 0.0;
+        for (int j = 0; j < b; ++j)
+            sum += tpm[b * i + j];
+
+        if (sum != 0.0)
+        {
+            for (int j = 0; j < b; ++j)
+            {
+                tpm[b * i + j] /= sum;
+            }
+        }
+        else
+        {
+            INFORM_ERROR(err, INFORM_ETPMROW);
+        }
+    }
+
+    return tpm;
+}


### PR DESCRIPTION
The function `inform_tpm` computes the transition probability matrix (TPM) for a time series. Each row of the TPM is normalized (or all zeros if no transitions are observed).

Closes #39 