### PR TITLE
Implement accumulation functionality for distributions

### DIFF
--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -250,6 +250,20 @@ EXPORT double inform_dist_prob(inform_dist const *dist, size_t event);
  * @return the number of probabilities written to the array
  */
 EXPORT size_t inform_dist_dump(inform_dist const *dist, double *probs, size_t n);
+/**
+ * Accumulate observations from a series.
+ *
+ * If an invalid distribution is provided, no events will be observed (0 will
+ * be returned). If an invalid event is provided, then the number of valid
+ * events to that point will be returned.
+ *
+ * @param[in,out] dist the distribution
+ * @param[in] events the events to observe
+ * @param[in] n the number of events provided
+ * @return the number of valid observations
+ */
+EXPORT size_t inform_dist_accumulate(inform_dist *dist, int const *events,
+    size_t n);
 
 #ifdef __cplusplus
 }

--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -258,8 +258,8 @@ EXPORT size_t inform_dist_dump(inform_dist const *dist, double *probs, size_t n)
  * events to that point will be returned.
  *
  * @param[in,out] dist the distribution
- * @param[in] events the events to observe
- * @param[in] n the number of events provided
+ * @param[in] events   the events to observe
+ * @param[in] n        the number of events provided
  * @return the number of valid observations
  */
 EXPORT size_t inform_dist_accumulate(inform_dist *dist, int const *events,

--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -128,6 +128,14 @@ EXPORT inform_dist* inform_dist_dup(inform_dist const *dist);
  */
 EXPORT inform_dist* inform_dist_create(uint32_t const *data, size_t n);
 /**
+ * Infer a distribution from a collection of observed events.
+ *
+ * @param[in] events   the events to observe
+ * @param[in] n        the number of events provided
+ * @return the new distribution
+ */
+EXPORT inform_dist* inform_dist_infer(int const *events, size_t n);
+/**
  * Free all dynamically allocated memory associated with a distribution.
  *
  * @param[in] dist the distribution to free

--- a/src/dist.c
+++ b/src/dist.c
@@ -151,7 +151,7 @@ inform_dist* inform_dist_dup(inform_dist const *dist)
 inform_dist* inform_dist_create(uint32_t const *data, size_t n)
 {
     // if the requested support size is zero, return NULL
-    if (n == 0)
+    if (data == NULL || n == 0)
     {
         return NULL;
     }

--- a/src/dist.c
+++ b/src/dist.c
@@ -293,3 +293,8 @@ size_t inform_dist_dump(inform_dist const *dist, double *probs, size_t n)
     }
     return (int) n;
 }
+
+size_t inform_dist_accumulate(inform_dist *dist, int const *events, size_t n)
+{
+    return 0;
+}

--- a/src/dist.c
+++ b/src/dist.c
@@ -185,6 +185,11 @@ inform_dist* inform_dist_create(uint32_t const *data, size_t n)
     return dist;
 }
 
+inform_dist* inform_dist_infer(int const *events, size_t n)
+{
+    return NULL;
+}
+
 void inform_dist_free(inform_dist *dist)
 {
     if (dist != NULL)

--- a/src/dist.c
+++ b/src/dist.c
@@ -195,7 +195,11 @@ inform_dist* inform_dist_infer(int const *events, size_t n)
     for (size_t i = 0; i < n; ++i)
     {
         event = events[i];
-        if (event < 0) break;
+        if (event < 0)
+        {
+            b = -2;
+            break;
+        }
         if (event > b) b = event;
     }
     if (b < 0) return NULL;
@@ -332,11 +336,11 @@ size_t inform_dist_accumulate(inform_dist *dist, int const *events, size_t n)
         return 0;
     }
     // loop over the events and add them to the distribution
-    size_t const size = dist->size;
+    int const size = (int)dist->size;
     size_t i = 0;
     while (i < n)
     {
-        if (*events >= size) break;
+        if (size <= *events || *events < 0) break;
         dist->histogram[*events] += 1;
         dist->counts += 1;
         ++events;

--- a/src/dist.c
+++ b/src/dist.c
@@ -187,7 +187,32 @@ inform_dist* inform_dist_create(uint32_t const *data, size_t n)
 
 inform_dist* inform_dist_infer(int const *events, size_t n)
 {
-    return NULL;
+    // if no events are observed, return NULL
+    if (events == NULL || n == 0) return NULL;
+
+    // infer the support
+    int b = -1, event = 0;
+    for (size_t i = 0; i < n; ++i)
+    {
+        event = events[i];
+        if (event < 0) break;
+        if (event > b) b = event;
+    }
+    if (b < 0) return NULL;
+    // the base is one greater than the largest observed event
+    b += 1;
+    // allocate the distribution
+    inform_dist *dist = inform_dist_alloc(b);
+    // accumulate the observations
+    if (dist != NULL)
+    {
+        if (inform_dist_accumulate(dist, events, n) != n)
+        {
+            inform_dist_free(dist);
+            dist = NULL;
+        }
+    }
+    return dist;
 }
 
 void inform_dist_free(inform_dist *dist)

--- a/src/dist.c
+++ b/src/dist.c
@@ -296,5 +296,21 @@ size_t inform_dist_dump(inform_dist const *dist, double *probs, size_t n)
 
 size_t inform_dist_accumulate(inform_dist *dist, int const *events, size_t n)
 {
-    return 0;
+    // if the distribution is invalid or no events were provided
+    if (dist == NULL || events == NULL || dist->size == 0)
+    {
+        return 0;
+    }
+    // loop over the events and add them to the distribution
+    size_t const size = dist->size;
+    size_t i = 0;
+    while (i < n)
+    {
+        if (*events >= size) break;
+        dist->histogram[*events] += 1;
+        dist->counts += 1;
+        ++events;
+        ++i;
+    }
+    return i;
 }

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -268,6 +268,38 @@ UNIT(Dup)
     inform_dist_free(dist);
 }
 
+UNIT(Infer)
+{
+    ASSERT_NULL(inform_dist_infer(NULL, 0));
+    ASSERT_NULL(inform_dist_infer(NULL, 1));
+    ASSERT_NULL(inform_dist_infer((int[3]){0,0,1}, 0));
+    ASSERT_NULL(inform_dist_infer((int[3]){0,-1,2}, 3));
+
+    inform_dist *dist = inform_dist_infer((int[4]){0,1,1,1}, 4);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(2, inform_dist_size(dist));
+    ASSERT_EQUAL(4, inform_dist_counts(dist));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 1));
+    inform_dist_free(dist);
+
+    dist = inform_dist_infer((int[8]){1,1,0,2,2,1,2,0}, 8);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(3, inform_dist_size(dist));
+    ASSERT_EQUAL(8, inform_dist_counts(dist));
+    ASSERT_EQUAL(2, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 1));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 2));
+    inform_dist_free(dist);
+
+    dist = inform_dist_infer((int[5]){0,0,0,0,0}, 5);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(1, inform_dist_size(dist));
+    ASSERT_EQUAL(5, inform_dist_counts(dist));
+    ASSERT_EQUAL(5, inform_dist_get(dist, 0));
+    inform_dist_free(dist);
+}
+
 UNIT(Tick)
 {
     inform_dist *dist = inform_dist_alloc(3);
@@ -389,6 +421,7 @@ BEGIN_SUITE(Distribution)
     ADD_UNIT(CopyResize)
     ADD_UNIT(DupNull)
     ADD_UNIT(Dup)
+    ADD_UNIT(Infer)
     ADD_UNIT(Tick)
     ADD_UNIT(Prob)
     ADD_UNIT(Dump)

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -340,6 +340,37 @@ UNIT(Dump)
     inform_dist_free(dist);
 }
 
+UNIT(Accumulate)
+{
+    inform_dist *dist = NULL;
+    ASSERT_EQUAL(0, inform_dist_accumulate(dist, (int[4]){0, 0, 1, 0}, 4));
+
+    dist = inform_dist_alloc(2);
+    ASSERT_NOT_NULL(dist);
+
+    ASSERT_EQUAL_U(0, inform_dist_accumulate(dist, NULL, 0));
+    ASSERT_EQUAL_U(0, inform_dist_accumulate(dist, NULL, 1));
+
+    ASSERT_EQUAL_U(0, inform_dist_accumulate(dist, (int[5]){0,0,1,1,0}, 0));
+
+    ASSERT_EQUAL_U(5, inform_dist_accumulate(dist, (int[5]){0,0,1,1,0}, 5));
+    ASSERT_EQUAL(5, inform_dist_counts(dist));
+    
+    ASSERT_EQUAL_U(3, inform_dist_accumulate(dist, (int[3]){0,1,0}, 3));
+    ASSERT_EQUAL(8, inform_dist_counts(dist));
+    
+    ASSERT_EQUAL(5, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 1));
+
+    ASSERT_EQUAL(0, inform_dist_accumulate(dist, (int[2]){-1, 2}, 2));
+    ASSERT_EQUAL(1, inform_dist_accumulate(dist, (int[2]){1, 2}, 2));
+    ASSERT_EQUAL(5, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(4, inform_dist_get(dist, 1));
+    ASSERT_EQUAL(9, inform_dist_counts(dist));
+
+    inform_dist_free(dist);
+}
+
 BEGIN_SUITE(Distribution)
     ADD_UNIT(AllocZero)
     ADD_UNIT(AllocOne)
@@ -361,4 +392,5 @@ BEGIN_SUITE(Distribution)
     ADD_UNIT(Tick)
     ADD_UNIT(Prob)
     ADD_UNIT(Dump)
+    ADD_UNIT(Accumulate)
 END_SUITE

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -268,6 +268,37 @@ UNIT(Dup)
     inform_dist_free(dist);
 }
 
+UNIT(Create)
+{
+    ASSERT_NULL(inform_dist_create(NULL, 0));
+    ASSERT_NULL(inform_dist_create(NULL, 1));
+    ASSERT_NULL(inform_dist_create((uint32_t[3]){3,4,5}, 0));
+
+    inform_dist *dist = inform_dist_create((uint32_t[3]){3,4,5}, 1);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(1, inform_dist_size(dist));
+    ASSERT_EQUAL(3, inform_dist_counts(dist));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 0));
+    inform_dist_free(dist);
+
+    dist = inform_dist_create((uint32_t[3]){3,4,5}, 2);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(2, inform_dist_size(dist));
+    ASSERT_EQUAL(7, inform_dist_counts(dist));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(4, inform_dist_get(dist, 1));
+    inform_dist_free(dist);
+
+    dist = inform_dist_create((uint32_t[3]){3,4,5}, 3);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(3, inform_dist_size(dist));
+    ASSERT_EQUAL(12, inform_dist_counts(dist));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(4, inform_dist_get(dist, 1));
+    ASSERT_EQUAL(5, inform_dist_get(dist, 2));
+    inform_dist_free(dist);
+}
+
 UNIT(Infer)
 {
     ASSERT_NULL(inform_dist_infer(NULL, 0));
@@ -421,6 +452,7 @@ BEGIN_SUITE(Distribution)
     ADD_UNIT(CopyResize)
     ADD_UNIT(DupNull)
     ADD_UNIT(Dup)
+    ADD_UNIT(Create)
     ADD_UNIT(Infer)
     ADD_UNIT(Tick)
     ADD_UNIT(Prob)


### PR DESCRIPTION
We've added two new functions for distributions: `inform_dist_infer` and `inform_dist_accumulate`. The former infers a distribution from an array of events, while the latter accumulates events into an already existent distribution.

We also added unit tests for `inform_dist_create` and resolved an otherwise undiscovered bug.

This closes #30