### PR TITLE
Approximate Distributions

### DIFF
--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -136,6 +136,16 @@ EXPORT inform_dist* inform_dist_create(uint32_t const *data, size_t n);
  */
 EXPORT inform_dist* inform_dist_infer(int const *events, size_t n);
 /**
+ * Approximate a given probability distribution to a given tolerance.
+ *
+ * @param[in] probs the probabilities
+ * @param[in] n     the number of probabilities
+ * @param[in] tol   the acceptable tolerance
+ * @return the new distribution
+ */
+EXPORT inform_dist* inform_dist_approximate(double const *probs, size_t n,
+    double tol);
+/**
  * Free all dynamically allocated memory associated with a distribution.
  *
  * @param[in] dist the distribution to free

--- a/src/dist.c
+++ b/src/dist.c
@@ -185,6 +185,11 @@ inform_dist* inform_dist_create(uint32_t const *data, size_t n)
     return dist;
 }
 
+inform_dist* inform_dist_approximate(double const *probs, size_t n, double tol)
+{
+    return NULL;
+}
+
 inform_dist* inform_dist_infer(int const *events, size_t n)
 {
     // if no events are observed, return NULL

--- a/src/dist.c
+++ b/src/dist.c
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 #include <inform/dist.h>
 #include <string.h>
+#include <math.h>
 
 inform_dist* inform_dist_alloc(size_t n)
 {
@@ -185,9 +186,61 @@ inform_dist* inform_dist_create(uint32_t const *data, size_t n)
     return dist;
 }
 
+static inline int gcd(uint32_t const *data, size_t n)
+{
+    if (n == 0)
+    {
+        return 1;
+    }
+    uint32_t x, temp, gcd = data[0];
+    for (size_t i = 1; i < n; ++i)
+    {
+        x = data[i];
+        while (x != 0)
+        {
+            temp = x;
+            x = gcd % x;
+            gcd = temp;
+        }
+    }
+    return gcd;
+}
+
 inform_dist* inform_dist_approximate(double const *probs, size_t n, double tol)
 {
-    return NULL;
+    if (probs == NULL || n == 0)
+    {
+        return NULL;
+    }
+    tol = fabs(tol);
+    // check the validity of the probability distribution
+    double diff = 1.0;
+    for (size_t i = 0; i < n; ++i)
+    {
+        diff -= probs[i];
+        if (probs[i] < 0.0) return NULL;
+    }
+    if (fabs(diff) > (double)n * tol)
+    {
+        return NULL;
+    }
+    // determine the number of counts
+    uint32_t *counts = malloc(n * sizeof(int));
+    if (counts == NULL)
+    {
+        return NULL;
+    }
+    for (size_t i = 0; i < n; ++i)
+    {
+        counts[i] = (uint32_t)(probs[i] / tol);
+    }
+    int g = gcd(counts, n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        counts[i] /= g;
+    }
+    // create the distribution
+    return inform_dist_create(counts, n);
 }
 
 inform_dist* inform_dist_infer(int const *events, size_t n)

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -331,6 +331,81 @@ UNIT(Infer)
     inform_dist_free(dist);
 }
 
+UNIT(Approximate)
+{
+    ASSERT_NULL(inform_dist_approximate(NULL, 0, 1e-6));
+    ASSERT_NULL(inform_dist_approximate(NULL, 1, 1e-6));
+    ASSERT_NULL(inform_dist_approximate((double[3]){0.5,0.2,0.3}, 0, 1e-6));
+    ASSERT_NULL(inform_dist_approximate((double[3]){0.5,0.2,0.3}, 1, 1e-6));
+    ASSERT_NULL(inform_dist_approximate((double[3]){0.5,0.2,0.3}, 2, 1e-6));
+
+    ASSERT_NULL(inform_dist_approximate((double[1]){0.5}, 1, 1e-6));
+    ASSERT_NULL(inform_dist_approximate((double[2]){0.5, 0.6}, 2, 1e-6));
+    ASSERT_NULL(inform_dist_approximate((double[2]){0.5, 0.5+3e-6}, 2, 1e-6));
+
+    inform_dist *dist = NULL;
+
+    dist = inform_dist_approximate((double[3]){0.5,0.2,0.3}, 3, 1e-3);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(3, inform_dist_size(dist));
+    ASSERT_EQUAL(10, inform_dist_counts(dist));
+    ASSERT_EQUAL(5, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(2, inform_dist_get(dist, 1));
+    ASSERT_EQUAL(3, inform_dist_get(dist, 2));
+    inform_dist_free(dist);
+
+    dist = inform_dist_approximate((double[3]){0.25,0.25,0.5}, 3, 1e-3);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(3, inform_dist_size(dist));
+    ASSERT_EQUAL(4, inform_dist_counts(dist));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 1));
+    ASSERT_EQUAL(2, inform_dist_get(dist, 2));
+    inform_dist_free(dist);
+
+    dist = inform_dist_approximate((double[2]){1./3, 2./3}, 2, 1e-3);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(2, inform_dist_size(dist));
+    ASSERT_EQUAL(3, inform_dist_counts(dist));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(2, inform_dist_get(dist, 1));
+    inform_dist_free(dist);
+
+    {
+        double expected[4] = {1./3, 1./3, 1./6, 1./6};
+        double got[4];
+        dist = inform_dist_approximate(expected, 4, 1e-3);
+        ASSERT_TRUE(inform_dist_is_valid(dist));
+        ASSERT_EQUAL_U(4, inform_dist_size(dist));
+        ASSERT_EQUAL(998, inform_dist_counts(dist));
+        ASSERT_EQUAL(333, inform_dist_get(dist, 0));
+        ASSERT_EQUAL(333, inform_dist_get(dist, 1));
+        ASSERT_EQUAL(166, inform_dist_get(dist, 2));
+        ASSERT_EQUAL(166, inform_dist_get(dist, 3));
+        inform_dist_dump(dist, got, 4);
+        for (size_t i = 0; i < 4; ++i)
+            ASSERT_DBL_NEAR_TOL(expected[i], got[i], 1e-3);
+        inform_dist_free(dist);
+    }
+
+    {
+        double expected[4] = {1./7, 2./7, 1./3, 10./42};
+        double got[4];
+        dist = inform_dist_approximate(expected, 4, 1e-3);
+        ASSERT_TRUE(inform_dist_is_valid(dist));
+        ASSERT_EQUAL_U(4, inform_dist_size(dist));
+        ASSERT_EQUAL(998, inform_dist_counts(dist));
+        ASSERT_EQUAL(142, inform_dist_get(dist, 0));
+        ASSERT_EQUAL(285, inform_dist_get(dist, 1));
+        ASSERT_EQUAL(333, inform_dist_get(dist, 2));
+        ASSERT_EQUAL(238, inform_dist_get(dist, 3));
+        inform_dist_dump(dist, got, 4);
+        for (size_t i = 0; i < 4; ++i)
+            ASSERT_DBL_NEAR_TOL(expected[i], got[i], 1e-3);
+        inform_dist_free(dist);
+    }
+}
+
 UNIT(Tick)
 {
     inform_dist *dist = inform_dist_alloc(3);
@@ -454,6 +529,7 @@ BEGIN_SUITE(Distribution)
     ADD_UNIT(Dup)
     ADD_UNIT(Create)
     ADD_UNIT(Infer)
+    ADD_UNIT(Approximate)
     ADD_UNIT(Tick)
     ADD_UNIT(Prob)
     ADD_UNIT(Dump)


### PR DESCRIPTION
It is useful to be able to approximate a probability distribution with an `inform_dist`. We implemented `inform_dist_approximate` specifically for that purpose.

This closes #47 