### PR TITLE
Construct Uniform Distributions

### DIFF
--- a/include/inform/dist.h
+++ b/include/inform/dist.h
@@ -146,6 +146,12 @@ EXPORT inform_dist* inform_dist_infer(int const *events, size_t n);
 EXPORT inform_dist* inform_dist_approximate(double const *probs, size_t n,
     double tol);
 /**
+ * Create a uniform distribution of a given size.
+ * @param[in] n the size of the distribution
+ * @return the new distribution
+ */
+EXPORT inform_dist* inform_dist_uniform(size_t n);
+/**
  * Free all dynamically allocated memory associated with a distribution.
  *
  * @param[in] dist the distribution to free

--- a/src/dist.c
+++ b/src/dist.c
@@ -277,6 +277,11 @@ inform_dist* inform_dist_infer(int const *events, size_t n)
     return dist;
 }
 
+inform_dist* inform_dist_uniform(size_t n)
+{
+    return NULL;
+}
+
 void inform_dist_free(inform_dist *dist)
 {
     if (dist != NULL)

--- a/src/dist.c
+++ b/src/dist.c
@@ -279,7 +279,16 @@ inform_dist* inform_dist_infer(int const *events, size_t n)
 
 inform_dist* inform_dist_uniform(size_t n)
 {
-    return NULL;
+    // construct a distribution of the desired size
+    inform_dist *dist = inform_dist_alloc(n);
+    if (dist != NULL)
+    {
+        // set the counts to the number of states
+        dist->counts = n;
+        // set the count for each state to 1
+        for (size_t i = 0; i < n; ++i) dist->histogram[i] = 1;
+    }
+    return dist;
 }
 
 void inform_dist_free(inform_dist *dist)

--- a/test/unittests/dist.c
+++ b/test/unittests/dist.c
@@ -406,6 +406,36 @@ UNIT(Approximate)
     }
 }
 
+UNIT(Uniform)
+{
+    inform_dist *dist;
+    ASSERT_NULL(inform_dist_uniform(0));
+
+    dist = inform_dist_uniform(1);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(1, inform_dist_size(dist));
+    ASSERT_EQUAL(1, inform_dist_counts(dist));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 0));
+    inform_dist_free(dist);
+
+    dist = inform_dist_uniform(2);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(2, inform_dist_size(dist));
+    ASSERT_EQUAL(2, inform_dist_counts(dist));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 1));
+    inform_dist_free(dist);
+
+    dist = inform_dist_uniform(3);
+    ASSERT_TRUE(inform_dist_is_valid(dist));
+    ASSERT_EQUAL_U(3, inform_dist_size(dist));
+    ASSERT_EQUAL(3, inform_dist_counts(dist));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 0));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 1));
+    ASSERT_EQUAL(1, inform_dist_get(dist, 2));
+    inform_dist_free(dist);
+}
+
 UNIT(Tick)
 {
     inform_dist *dist = inform_dist_alloc(3);
@@ -530,6 +560,7 @@ BEGIN_SUITE(Distribution)
     ADD_UNIT(Create)
     ADD_UNIT(Infer)
     ADD_UNIT(Approximate)
+    ADD_UNIT(Uniform)
     ADD_UNIT(Tick)
     ADD_UNIT(Prob)
     ADD_UNIT(Dump)


### PR DESCRIPTION
We created the `inform_dist_uniform` function which constructs a uniform distribution of a given size.

This closes #52 