### PR TITLE
Implement black boxing

### DIFF
--- a/include/inform/utilities.h
+++ b/include/inform/utilities.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <inform/utilities/binning.h>
+#include <inform/utilities/black_boxing.h>
 #include <inform/utilities/coalesce.h>
 #include <inform/utilities/encoding.h>
 #include <inform/utilities/random.h>

--- a/include/inform/utilities/black_boxing.h
+++ b/include/inform/utilities/black_boxing.h
@@ -1,0 +1,34 @@
+// Copyright 2016-2017 ELIFE. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+#pragma once
+
+#include <inform/error.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Black box a collection of time series, of various bases, history lengths,
+ * and future lengths.
+ *
+ * @param[in] series    the time series
+ * @param[in] l         the number of time series
+ * @param[in] n         the number of initial conditions in each time series
+ * @param[in] m         the number of time steps for each initial condition
+ * @param[in] b         the base of each time series
+ * @param[in] r         the history length for each time series
+ * @param[in] s         the future length for each time series
+ * @param[in,out] box   the array in which to put the black boxed time series
+ * @param[in,out] err   an error code
+ * @return the black boxed time series
+ */
+EXPORT int *inform_black_box(int const *series, size_t l, size_t n, size_t m,
+    int const *b, size_t const *r, size_t const *s, int *box,
+    inform_error *err);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${PROJECT_NAME}_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/shannon.c
     ${CMAKE_CURRENT_SOURCE_DIR}/transfer_entropy.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/binning.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/utilities/black_boxing.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/coalesce.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/encoding.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/random.c

--- a/src/utilities/black_boxing.c
+++ b/src/utilities/black_boxing.c
@@ -1,0 +1,10 @@
+// Copyright 2016-2017 ELIFE. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+#include <inform/error.h>
+
+int* inform_black_box(int const *series, size_t l, size_t n, size_t m,
+    int const *b, size_t const *r, size_t const *s, int *box, inform_error *err)
+{
+    return NULL;
+}

--- a/src/utilities/black_boxing.c
+++ b/src/utilities/black_boxing.c
@@ -2,9 +2,197 @@
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 #include <inform/error.h>
+#include <string.h>
+
+static bool check_arguments(int const *series, size_t l, size_t n, size_t m,
+    int const *b, size_t const *r, size_t const *s, inform_error *err)
+{
+
+    if (series == NULL)
+    {
+        INFORM_ERROR_RETURN(err, INFORM_ETIMESERIES, true);
+    }
+    else if (l == 0)
+    {
+        INFORM_ERROR_RETURN(err, INFORM_ENOSOURCES, true);
+    }
+    else if (n == 0)
+    {
+        INFORM_ERROR_RETURN(err, INFORM_ENOINITS, true);
+    }
+    else if (m == 0)
+    {
+        INFORM_ERROR_RETURN(err, INFORM_ESHORTSERIES, true);
+    }
+    else if (b == NULL)
+    {
+        INFORM_ERROR_RETURN(err, INFORM_EBASE, true);
+    }
+    else if (r != NULL)
+    {
+        if (s != NULL)
+        {
+            for (size_t i = 0; i < l; ++i)
+            {
+                if (r[i] == 0 && s[i] == 0)
+                    INFORM_ERROR_RETURN(err, INFORM_EKZERO, true);
+                if (r[i] + s[i] > m)
+                    INFORM_ERROR_RETURN(err, INFORM_EKLONG, true);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < l; ++i)
+            {
+                if (r[i] == 0)
+                    INFORM_ERROR_RETURN(err, INFORM_EKZERO, true);
+                if (r[i] > m)
+                    INFORM_ERROR_RETURN(err, INFORM_EKLONG, true);
+            }
+        }
+    }
+    for (size_t i = 0; i < l; ++i)
+    {
+        if (b[i] < 2)
+        {
+            INFORM_ERROR_RETURN(err, INFORM_EBASE, true);
+        }
+    }
+    for (size_t i = 0; i < l; ++i)
+    {
+        for (size_t j = 0; j < n * m; ++j)
+        {
+            if (series[n*m*i + j] < 0)
+            {
+                INFORM_ERROR_RETURN(err, INFORM_ENEGSTATE, true);
+            }
+            else if (series[n*m*i + j] >= b[i])
+            {
+                INFORM_ERROR_RETURN(err, INFORM_EBADSTATE, true);
+            }
+        }
+    }
+
+    return false;
+}
+
+static void compute_lengths(size_t const *r, size_t const *s, size_t l,
+    size_t *max_r, size_t *max_s)
+{
+    *max_r = 1;
+    *max_s = 0;
+    if (r != NULL && s == NULL)
+    {
+        *max_s = 0;
+        for (size_t i = 0; i < l; ++i)
+            *max_r = (r[i] > *max_r) ? r[i] : *max_r;
+    }
+    else if (r == NULL && s != NULL)
+    {
+        *max_r = 1;
+        for (size_t i = 0; i < l; ++i)
+            *max_s = (s[i] > *max_s) ? s[i] : *max_s;
+    }
+    else if (r != NULL && s != NULL)
+    {
+        for (size_t i = 0; i < l; ++i)
+        {
+            *max_r = (r[i] > *max_r) ? r[i] : *max_r;
+            *max_s = (s[i] > *max_s) ? s[i] : *max_s;
+        }
+    }
+}
+
+static void accumulate(int const *series, size_t l, size_t n, size_t m,
+    int const *b, size_t const *r, size_t const *s, size_t max_r, size_t max_s,
+    int *box, inform_error *err)
+{
+    int *data = malloc(2 * l * sizeof(int));
+    if (data == NULL) INFORM_ERROR_RETURN_VOID(err, INFORM_ENOMEM);
+
+    int *qs = data, *states = qs + l;
+    size_t const w = m - max_r - max_s + 1;
+    for (size_t i = 0; i < n * w; ++i) box[i] = 0;
+    
+    for (size_t i = 0; i < l; ++i)
+    {
+        for (size_t j = 0; j < n; ++j)
+        {
+            qs[i] = 1;
+            states[i] = 0;
+            for (size_t k = max_r - r[i]; k < max_r + s[i]; ++k)
+            {
+                qs[i] *= b[i];
+                states[i] *= b[i];
+                states[i] += series[k + m * (j + n * i)];
+            }
+            box[w * j] *= qs[i];
+            box[w * j] += states[i];
+
+            for (size_t k = max_r; k < m - max_s; ++k)
+            {
+                states[i] *= b[i];
+                states[i] -= series[k - r[i] + m * (j + n * i)] * qs[i];
+                states[i] += series[k + s[i] + m * (j + n * i)];
+                box[k - max_r + 1 + w * j] *= qs[i];
+                box[k - max_r + 1 + w * j] += states[i];
+            }
+        }
+    }
+        
+    free(data);
+}
 
 int* inform_black_box(int const *series, size_t l, size_t n, size_t m,
     int const *b, size_t const *r, size_t const *s, int *box, inform_error *err)
 {
-    return NULL;
+    if (check_arguments(series, l, n, m, b, r, s, err))
+    {
+        return NULL;
+    }
+    size_t max_r, max_s;
+    compute_lengths(r, s, l, &max_r, &max_s);
+
+    bool allocate = (box == NULL);
+    if (allocate)
+    {
+        box = calloc(n * (m - max_r - max_s + 1), sizeof(int));
+        if (box == NULL)
+        {
+            INFORM_ERROR_RETURN(err, INFORM_ENOMEM, NULL);
+        }
+    }
+
+    size_t *data = calloc(2 * l, sizeof(size_t));
+    if (data == NULL)
+    {
+        if (allocate) free(box);
+        INFORM_ERROR_RETURN(err, INFORM_ENOMEM, NULL);
+    }
+
+    size_t *history = data;
+    if (r == NULL)
+    {
+        for (size_t i = 0; i < l; ++i) history[i] = 1;
+    }
+    else
+    {
+        memcpy(history, r, l * sizeof(size_t));
+    }
+
+    size_t *future = data + l;
+    if (s != NULL)
+    {
+        memcpy(future, s, l * sizeof(size_t));
+    }
+
+    accumulate(series, l, n, m, b, history, future, max_r, max_s, box, err);
+
+    if (inform_failed(err))
+    {
+        if (allocate) free(box);
+        box = NULL;
+    }
+    free(data);
+    return box;
 }

--- a/test/unittests/utilities.c
+++ b/test/unittests/utilities.c
@@ -883,7 +883,7 @@ UNIT(BlackBoxSingleSeries)
         int series[8] = {0,1,1,0,1,1,0,0};
         int expect[6] = {3,6,5,3,6,4};
         inform_black_box(series, 1, 1, 8, (int[]){2}, (size_t[]){3}, NULL, box, &err);
-        for (size_t i = 0; i < 7; ++i)
+        for (size_t i = 0; i < 6; ++i)
             ASSERT_EQUAL(expect[i], box[i]);
     }
     {
@@ -907,7 +907,7 @@ UNIT(BlackBoxSingleSeries)
         int series[8] = {0,1,1,0,1,1,0,0};
         int expect[6] = {3,6,5,3,6,4};
         inform_black_box(series, 1, 1, 8, (int[]){2}, NULL, (size_t[]){2}, box, &err);
-        for (size_t i = 0; i < 7; ++i)
+        for (size_t i = 0; i < 6; ++i)
             ASSERT_EQUAL(expect[i], box[i]);
     }
     {
@@ -915,7 +915,7 @@ UNIT(BlackBoxSingleSeries)
         int series[8] = {0,1,1,0,1,1,0,0};
         int expect[6] = {3,6,5,3,6,4};
         inform_black_box(series, 1, 1, 8, (int[]){2}, (size_t[]){1}, (size_t[]){2}, box, &err);
-        for (size_t i = 0; i < 7; ++i)
+        for (size_t i = 0; i < 6; ++i)
             ASSERT_EQUAL(expect[i], box[i]);
     }
     {
@@ -923,7 +923,7 @@ UNIT(BlackBoxSingleSeries)
         int series[8] = {0,1,2,0,1,1,0,2};
         int expect[6] = {5,15,19,4,12,11};
         inform_black_box(series, 1, 1, 8, (int[]){3}, (size_t[]){1}, (size_t[]){2}, box, &err);
-        for (size_t i = 0; i < 7; ++i)
+        for (size_t i = 0; i < 6; ++i)
             ASSERT_EQUAL(expect[i], box[i]);
     }
 }


### PR DESCRIPTION
This pull request brings in the `inform_black_box` function. This function takes a collection of time series, and block boxes them using provide history and future lengths. The time series may have different bases, different history lengths, and different future lengths.

This closes issue #54 