### PR TITLE
Rename inform_shannon

### DIFF
--- a/include/inform/shannon/univariate.h
+++ b/include/inform/shannon/univariate.h
@@ -33,7 +33,7 @@ EXPORT double inform_shannon_si(inform_dist const *dist, size_t event, double ba
  * @param[in] base the logarithmic base
  * @return the shannon information
  */
-EXPORT double inform_shannon(inform_dist const *dist, double base);
+EXPORT double inform_shannon_entropy(inform_dist const *dist, double base);
 
 /**
  * Compute the pointwise mutual information of an combination of events

--- a/src/block_entropy.c
+++ b/src/block_entropy.c
@@ -110,7 +110,7 @@ double inform_block_entropy(int const *series, size_t n, size_t m, int b,
         accumulate_observations(series, m, b, k, &states);
     }
 
-    double be = inform_shannon(&states, 2.0);
+    double be = inform_shannon_entropy(&states, 2.0);
 
     free(data);
 

--- a/src/shannon/multivariate.c
+++ b/src/shannon/multivariate.c
@@ -28,10 +28,10 @@ double inform_shannon_multi_mi(inform_dist const *joint,
     {
         return 0.0;
     }
-    double pmi = -inform_shannon(joint, base);
+    double pmi = -inform_shannon_entropy(joint, base);
     for (size_t i = 0; i < n; ++i)
     {
-        pmi += inform_shannon(marginals[i], base);
+        pmi += inform_shannon_entropy(marginals[i], base);
     }
     return pmi;
 }

--- a/src/shannon/univariate.c
+++ b/src/shannon/univariate.c
@@ -14,7 +14,7 @@ double inform_shannon_si(inform_dist const *dist, size_t event, double base)
     return NAN;
 }
 
-double inform_shannon(inform_dist const *dist, double base)
+double inform_shannon_entropy(inform_dist const *dist, double base)
 {
     // ensure that the distribution is valid
     if (inform_dist_is_valid(dist))
@@ -67,7 +67,8 @@ double inform_shannon_pce(inform_dist const *joint, inform_dist const *marginal,
 double inform_shannon_ce(inform_dist const *joint, inform_dist const *marginal,
     double base)
 {
-    return inform_shannon(joint, base) - inform_shannon(marginal, base);
+    return inform_shannon_entropy(joint, base) -
+        inform_shannon_entropy(marginal, base);
 }
 
 double inform_shannon_pcmi(inform_dist const *joint,
@@ -86,10 +87,10 @@ double inform_shannon_cmi(inform_dist const *joint,
     inform_dist const *marginal_xz, inform_dist const *marginal_yz,
     inform_dist const *marginal_z, double base)
 {
-    return inform_shannon(marginal_xz, base) +
-        inform_shannon(marginal_yz, base) -
-        inform_shannon(joint, base) -
-        inform_shannon(marginal_z, base);
+    return inform_shannon_entropy(marginal_xz, base) +
+        inform_shannon_entropy(marginal_yz, base) -
+        inform_shannon_entropy(joint, base) -
+        inform_shannon_entropy(marginal_z, base);
 }
 
 double inform_shannon_pre(inform_dist const *p, inform_dist const *q,

--- a/src/transfer_entropy.c
+++ b/src/transfer_entropy.c
@@ -143,10 +143,10 @@ double inform_transfer_entropy(int const *node_y, int const *node_x, size_t n,
         accumulate_observations(node_y, node_x, m, b, k, &states, &histories, &sources, &predicates);
     }
 
-    double te = inform_shannon(&sources, 2.0) +
-        inform_shannon(&predicates, 2.0) -
-        inform_shannon(&states, 2.0) -
-        inform_shannon(&histories, 2.0);
+    double te = inform_shannon_entropy(&sources, 2.0) +
+        inform_shannon_entropy(&predicates, 2.0) -
+        inform_shannon_entropy(&states, 2.0) -
+        inform_shannon_entropy(&histories, 2.0);
 
     free(data);
 

--- a/test/unittests/shannon/univariate.c
+++ b/test/unittests/shannon/univariate.c
@@ -10,10 +10,10 @@
 UNIT(ShannonUniInvalidDistribution)
 {
     inform_dist *dist = NULL;
-    ASSERT_TRUE(isnan(inform_shannon(dist, 2)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, 2)));
 
     dist = inform_dist_alloc(5);
-    ASSERT_TRUE(isnan(inform_shannon(dist, 2)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, 2)));
     inform_dist_free(dist);
 }
 
@@ -21,14 +21,14 @@ UNIT(ShannonUniDeltaFunction)
 {
     inform_dist *dist = inform_dist_alloc(5);
     inform_dist_fill(dist, 0, 1, 0, 0, 0);
-    ASSERT_TRUE(isnan(inform_shannon(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon(dist, -0.5)));
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 0.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 0.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 1.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 2), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 3), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 4), 1e-6);
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 1.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 2), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 3), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 4), 1e-6);
     inform_dist_free(dist);
 }
 
@@ -37,14 +37,14 @@ UNIT(ShannonUniUniform)
     inform_dist *dist = inform_dist_alloc(5);
     inform_dist_fill(dist, 1, 1, 1, 1, 1);
 
-    ASSERT_TRUE(isnan(inform_shannon(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon(dist, -0.5)));
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 0.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(-2.321928, inform_shannon(dist, 0.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(3.969362, inform_shannon(dist, 1.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(2.321928, inform_shannon(dist, 2), 1e-6);
-    ASSERT_DBL_NEAR_TOL(1.464973, inform_shannon(dist, 3), 1e-6);
-    ASSERT_DBL_NEAR_TOL(1.160964, inform_shannon(dist, 4), 1e-6);
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(-2.321928, inform_shannon_entropy(dist, 0.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(3.969362, inform_shannon_entropy(dist, 1.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(2.321928, inform_shannon_entropy(dist, 2), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.464973, inform_shannon_entropy(dist, 3), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.160964, inform_shannon_entropy(dist, 4), 1e-6);
     inform_dist_free(dist);
 }
 
@@ -53,38 +53,38 @@ UNIT(ShannonUniNonUniform)
     inform_dist *dist = inform_dist_alloc(2);
     inform_dist_fill(dist, 2, 1);
 
-    ASSERT_TRUE(isnan(inform_shannon(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon(dist, -0.5)));
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 0.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(-0.918295, inform_shannon(dist, 0.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(1.569837, inform_shannon(dist, 1.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.918295, inform_shannon(dist, 2), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.579380, inform_shannon(dist, 3), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.459148, inform_shannon(dist, 4), 1e-6);
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(-0.918295, inform_shannon_entropy(dist, 0.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.569837, inform_shannon_entropy(dist, 1.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.918295, inform_shannon_entropy(dist, 2), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.579380, inform_shannon_entropy(dist, 3), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.459148, inform_shannon_entropy(dist, 4), 1e-6);
 
     dist = inform_dist_realloc(dist, 3);
     inform_dist_fill(dist, 1, 1, 0);
 
-    ASSERT_TRUE(isnan(inform_shannon(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon(dist, -0.5)));
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 0.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(-1.000000, inform_shannon(dist, 0.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(1.709511, inform_shannon(dist, 1.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(1.000000, inform_shannon(dist, 2), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.630930, inform_shannon(dist, 3), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.500000, inform_shannon(dist, 4), 1e-6);
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(-1.000000, inform_shannon_entropy(dist, 0.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.709511, inform_shannon_entropy(dist, 1.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.000000, inform_shannon_entropy(dist, 2), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.630930, inform_shannon_entropy(dist, 3), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.500000, inform_shannon_entropy(dist, 4), 1e-6);
 
     inform_dist_fill(dist, 2, 2, 1);
-    ASSERT_DBL_NEAR_TOL(1.521928, inform_shannon(dist, 2), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.521928, inform_shannon_entropy(dist, 2), 1e-6);
 
-    ASSERT_TRUE(isnan(inform_shannon(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon(dist, -0.5)));
-    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon(dist, 0.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(-1.521928, inform_shannon(dist, 0.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(2.601753, inform_shannon(dist, 1.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(1.521928, inform_shannon(dist, 2), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.960230, inform_shannon(dist, 3), 1e-6);
-    ASSERT_DBL_NEAR_TOL(0.760964, inform_shannon(dist, 4), 1e-6);
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
+    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(-1.521928, inform_shannon_entropy(dist, 0.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(2.601753, inform_shannon_entropy(dist, 1.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(1.521928, inform_shannon_entropy(dist, 2), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.960230, inform_shannon_entropy(dist, 3), 1e-6);
+    ASSERT_DBL_NEAR_TOL(0.760964, inform_shannon_entropy(dist, 4), 1e-6);
 
     inform_dist_free(dist);
 }
@@ -421,12 +421,12 @@ UNIT(ShannonUniCrossEntropySameDist)
         inform_dist_set(p, i, inform_random_int(0, 100));
     ASSERT_TRUE(isnan(inform_shannon_cross(p, p, -1.0)));
     ASSERT_TRUE(isnan(inform_shannon_cross(p, p, -0.5)));
-    ASSERT_DBL_NEAR_TOL(inform_shannon(p, 0.0), inform_shannon_cross(p, p, 0.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(inform_shannon(p, 0.5), inform_shannon_cross(p, p, 0.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(inform_shannon(p, 1.5), inform_shannon_cross(p, p, 1.5), 1e-6);
-    ASSERT_DBL_NEAR_TOL(inform_shannon(p, 2.0), inform_shannon_cross(p, p, 2.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(inform_shannon(p, 3.0), inform_shannon_cross(p, p, 3.0), 1e-6);
-    ASSERT_DBL_NEAR_TOL(inform_shannon(p, 4.0), inform_shannon_cross(p, p, 4.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 0.0), inform_shannon_cross(p, p, 0.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 0.5), inform_shannon_cross(p, p, 0.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 1.5), inform_shannon_cross(p, p, 1.5), 1e-6);
+    ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 2.0), inform_shannon_cross(p, p, 2.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 3.0), inform_shannon_cross(p, p, 3.0), 1e-6);
+    ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 4.0), inform_shannon_cross(p, p, 4.0), 1e-6);
     inform_dist_free(p);
 }
 


### PR DESCRIPTION
For consistency with the rest of the measures, rename `inform_shannon` to `inform_shannon_entropy`.

Closes #64 