### PR TITLE
Return encoding error from inform_black_box

### DIFF
--- a/src/utilities/black_boxing.c
+++ b/src/utilities/black_boxing.c
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 #include <inform/error.h>
 #include <string.h>
+#include <math.h>
 
 static bool check_arguments(int const *series, size_t l, size_t n, size_t m,
     int const *b, size_t const *r, size_t const *s, inform_error *err)
@@ -51,12 +52,39 @@ static bool check_arguments(int const *series, size_t l, size_t n, size_t m,
             }
         }
     }
-    for (size_t i = 0; i < l; ++i)
+    double bits = 0.0;
+    if (r != NULL)
     {
-        if (b[i] < 2)
+        for (size_t i = 0; i < l; ++i)
         {
-            INFORM_ERROR_RETURN(err, INFORM_EBASE, true);
+            if (b[i] < 2)
+            {
+                INFORM_ERROR_RETURN(err, INFORM_EBASE, true);
+            }
+            bits += r[i] * log2(b[i]);
         }
+    }
+    else
+    {
+        for (size_t i = 0; i < l; ++i)
+        {
+            if (b[i] < 2)
+            {
+                INFORM_ERROR_RETURN(err, INFORM_EBASE, true);
+            }
+            bits += log2(b[i]);
+        }
+    }
+    if (s != NULL)
+    {
+        for (size_t i = 0; i < l; ++i)
+        {
+            bits += s[i] * log2(b[i]);
+        }
+    }
+    if (bits > 30.0)
+    {
+        INFORM_ERROR_RETURN(err, INFORM_EENCODE, true);
     }
     for (size_t i = 0; i < l; ++i)
     {

--- a/test/unittests/utilities.c
+++ b/test/unittests/utilities.c
@@ -843,6 +843,59 @@ UNIT(BlackBoxHistoryFutureTooLong)
     ASSERT_EQUAL(INFORM_EKLONG, err);
 }
 
+UNIT(BlackBoxEncodingError)
+{
+    inform_error err = INFORM_SUCCESS;
+    {
+        int series[32] = {0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,
+                          0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1};
+        err = INFORM_SUCCESS;
+        ASSERT_NULL(inform_black_box(series, 1, 1, 32, (int[]){2},
+            (size_t[]){31}, NULL, NULL, &err));
+        ASSERT_EQUAL(INFORM_EENCODE, err);
+    }
+    {
+        int series[32] = {0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,
+                          0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1};
+        err = INFORM_SUCCESS;
+        ASSERT_NULL(inform_black_box(series, 1, 1, 32, (int[]){4},
+            (size_t[]){16}, NULL, NULL, &err));
+        ASSERT_EQUAL(INFORM_EENCODE, err);
+    }
+    {
+        int series[32] = {0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,
+                          0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1};
+        err = INFORM_SUCCESS;
+        ASSERT_NULL(inform_black_box(series, 1, 1, 32, (int[]){4},
+            (size_t[]){29}, (size_t[]){2}, NULL, &err));
+        ASSERT_EQUAL(INFORM_EENCODE, err);
+    }
+    {
+        int series[38] = {0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0,
+                          0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0};
+        err = INFORM_SUCCESS;
+        ASSERT_NULL(inform_black_box(series, 2, 1, 16, (int[]){2,2},
+            (size_t[]){15, 16}, NULL, NULL, &err));
+        ASSERT_EQUAL(INFORM_EENCODE, err);
+    }
+    {
+        int series[38] = {0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0,
+                          0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0};
+        err = INFORM_SUCCESS;
+        ASSERT_NULL(inform_black_box(series, 2, 1, 16, (int[]){2,4},
+            (size_t[]){15, 8}, NULL, NULL, &err));
+        ASSERT_EQUAL(INFORM_EENCODE, err);
+    }
+    {
+        int series[38] = {0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0,
+                          0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0};
+        err = INFORM_SUCCESS;
+        ASSERT_NULL(inform_black_box(series, 2, 1, 16, (int[]){2,3},
+            (size_t[]){10, 5}, (size_t[]){4,6}, NULL, &err));
+        ASSERT_EQUAL(INFORM_EENCODE, err);
+    }
+}
+
 UNIT(BlackBoxAllocates)
 {
     inform_error err = INFORM_SUCCESS;
@@ -1343,6 +1396,7 @@ BEGIN_SUITE(Utilities)
     ADD_UNIT(BlackBoxInvalidState)
     ADD_UNIT(BlackBoxInvalidHistory)
     ADD_UNIT(BlackBoxHistoryFutureTooLong)
+    ADD_UNIT(BlackBoxEncodingError)
     ADD_UNIT(BlackBoxAllocates)
     ADD_UNIT(BlackBoxSingleSeries)
     ADD_UNIT(BlackBoxSingleSeriesEnsemble)


### PR DESCRIPTION
If, altogether, the encoding will require more than 30 bits, we will return an encoding error.

This fixes issue #63 