### PR TITLE
Improve Function Overhead

### DIFF
--- a/src/active_info.c
+++ b/src/active_info.c
@@ -182,10 +182,13 @@ double *inform_local_active_info(int const *series, size_t n, size_t m, int b,
     accumulate_local_observations(series, n, m, b, k, &states, &histories,
         &futures, state, history, future);
 
+    double r, s, t;
     for (size_t i = 0; i < N; ++i)
     {
-        ai[i] = inform_shannon_pmi(&states, &histories, &futures, state[i],
-            history[i], future[i], 2.0);
+        r = states.histogram[state[i]];
+        s = histories.histogram[history[i]];
+        t = futures.histogram[future[i]];
+        ai[i] = log2((r * N) / (s * t));
     }
 
     free(state_data);

--- a/src/block_entropy.c
+++ b/src/block_entropy.c
@@ -159,9 +159,11 @@ double *inform_local_block_entropy(int const *series, size_t n, size_t m, int b,
 
     accumulate_local_observations(series, n, m, b, k, &states, state);
 
+    double s;
     for (size_t i = 0; i < N; ++i)
     {
-        be[i] = inform_shannon_si(&states, state[i], 2.0);
+        s = states.histogram[state[i]];
+        be[i] = -log2(s/N);
     }
 
     free(state);

--- a/src/conditional_entropy.c
+++ b/src/conditional_entropy.c
@@ -114,10 +114,13 @@ double *inform_local_conditional_entropy(int const *xs, int const *ys,
 
     accumulate(xs, ys, n, by, x, xy);
 
+    double s, m;
     for (size_t i = 0; i < n; ++i)
     {
         int z = xs[i]*by + ys[i];
-        ce[i] = inform_shannon_pce(xy, x, z, xs[i], 2.0);
+        s = xy->histogram[z];
+        m = x->histogram[xs[i]];
+        ce[i] = log2(m/s);
     }
 
     free_all(&x, &xy);

--- a/src/entropy_rate.c
+++ b/src/entropy_rate.c
@@ -176,9 +176,12 @@ double *inform_local_entropy_rate(int const *series, size_t n, size_t m, int b,
     accumulate_local_observations(series, n, m, b, k, &states, &histories,
         state, history);
 
+    double s, h;
     for (size_t i = 0; i < N; ++i)
     {
-        er[i] = inform_shannon_pce(&states, &histories, state[i], history[i], 2.0);
+        s = states.histogram[state[i]];
+        h = histories.histogram[history[i]];
+        er[i] = log2(h/s);
     }
 
     free(state_data);

--- a/src/predictive_info.c
+++ b/src/predictive_info.c
@@ -4,37 +4,40 @@
 #include <inform/predictive_info.h>
 #include <inform/shannon.h>
 
-static void accumulate_observations(int const* series, size_t n, int b,
-    size_t kpast, size_t kfuture, inform_dist *states, inform_dist *histories,
-    inform_dist *futures)
+static void accumulate_observations(int const* series, size_t n, size_t m,
+    int b, size_t kpast, size_t kfuture, inform_dist *states,
+    inform_dist *histories, inform_dist *futures)
 {
-    int history = 0, q = 1, r = 1, state, future = 0;
-    for (size_t i = 0; i < kpast; ++i)
+    for (size_t i = 0; i < n; ++i, series += m)
     {
-        q *= b;
-        history *= b;
-        history += series[i];
+        int history = 0, q = 1, r = 1, state, future = 0;
+        for (size_t j = 0; j < kpast; ++j)
+        {
+            q *= b;
+            history *= b;
+            history += series[j];
+        }
+
+        for (size_t j = kpast; j < kpast + kfuture; ++j)
+        {
+            r *= b;
+            future *= b;
+            future += series[j];
+        }
+
+        size_t j = kpast + kfuture;
+        do
+        {
+            state = history * r + future;
+
+            states->histogram[state]++;
+            histories->histogram[history]++;
+            futures->histogram[future]++;
+
+            history = history * b - series[j - kpast - kfuture]*q + series[j - kfuture];
+            future = future * b - series[j - kfuture]*r + series[j];
+        } while (++j <= m);
     }
-
-    for (size_t i = kpast; i < kpast + kfuture; ++i)
-    {
-        r *= b;
-        future *= b;
-        future += series[i];
-    }
-
-    size_t i = kpast + kfuture;
-    do
-    {
-        state = history * r + future;
-
-        states->histogram[state]++;
-        histories->histogram[history]++;
-        futures->histogram[future]++;
-
-        history = history * b - series[i - kpast - kfuture]*q + series[i - kfuture];
-        future = future * b - series[i - kfuture]*r + series[i];
-    } while (++i <= n);
 }
 
 static void accumulate_local_observations(int const* series, size_t n, int b,
@@ -140,11 +143,8 @@ double inform_predictive_info(int const *series, size_t n, size_t m, int b,
     inform_dist histories = { data + states_size, histories_size, N };
     inform_dist futures   = { data + states_size + histories_size, futures_size, N };
 
-    for (size_t i = 0; i < n; ++i, series += m)
-    {
-        accumulate_observations(series, m, b, kpast, kfuture, &states,
-            &histories, &futures);
-    }
+    accumulate_observations(series, n, m, b, kpast, kfuture, &states,
+        &histories, &futures);
 
     double pi = inform_shannon_mi(&states, &histories, &futures, 2.0);
 

--- a/src/predictive_info.c
+++ b/src/predictive_info.c
@@ -208,10 +208,13 @@ double *inform_local_predictive_info(int const *series, size_t n, size_t m,
     accumulate_local_observations(series, n, m, b, kpast, kfuture, &states,
         &histories, &futures, state, history, future);
 
+    double s, h, f;
     for (size_t i = 0; i < N; ++i)
     {
-        pi[i] = inform_shannon_pmi(&states, &histories, &futures, state[i],
-            history[i], future[i], 2.0);
+        s = states.histogram[state[i]];
+        h = histories.histogram[history[i]];
+        f = futures.histogram[future[i]];
+        pi[i] = log2((s * N) / (h * f));
     }
 
     free(state_data);

--- a/src/relative_entropy.c
+++ b/src/relative_entropy.c
@@ -110,9 +110,12 @@ double *inform_local_relative_entropy(int const *xs, int const *ys, size_t n,
 
     accumulate(xs, ys, n, x, y);
 
+    double p, q;
     for (size_t i = 0; i < (size_t) b; ++i)
     {
-        re[i] = inform_shannon_pre(x, y, i, 2.0);
+        p = x->histogram[i];
+        q = y->histogram[i];
+        re[i] = log2(p / q);
     }
 
     free_all(&x, &y);

--- a/src/transfer_entropy.c
+++ b/src/transfer_entropy.c
@@ -213,10 +213,14 @@ double *inform_local_transfer_entropy(int const *node_y, int const *node_x,
     accumulate_local_observations(node_y, node_x, n, m, b, k, &states,
         &histories, &sources, &predicates, state, history, source, predicate);
 
+    double r, s, t, u;
     for (size_t i = 0; i < N; ++i)
     {
-        te[i] = inform_shannon_pcmi(&states, &sources, &predicates, &histories,
-            state[i], source[i], predicate[i], history[i], 2.0);
+        r = states.histogram[state[i]];
+        s = sources.histogram[source[i]];
+        t = predicates.histogram[predicate[i]];
+        u = histories.histogram[history[i]];
+        te[i] = log2((r*u)/(s*t));
     }
 
     free(state_data);


### PR DESCRIPTION
Most of the local measures were employing the `inform_shannon_*` functions internally. This is great for code reuse, but has a huge performance cost (2-10x in some cases).

We've gone through all of the measures and attempted to remove function calls from tight loops. This seems to have greatly improved the overall performance.

This pull request addresses #42 