### PR TITLE
Improve floating-point assertions

### DIFF
--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -160,6 +160,12 @@ inline static void assert_not_nan(double real, char const *caller, int line);
 inline static void assert_nan(double real, char const *caller, int line);
 #define ASSERT_NAN(real) assert_nan(real, __FILE__, __LINE__);
 
+inline static void assert_not_inf(double real, char const *caller, int line);
+#define ASSERT_NOT_INF(real) assert_not_inf(real, __FILE__, __LINE__);
+
+inline static void assert_inf(double real, char const *caller, int line);
+#define ASSERT_INF(real) assert_inf(real, __FILE__, __LINE__);
+
 inline static void assert_dbl_near(double exp, double real, double tol, char const *caller, int line);
 #define ASSERT_DBL_NEAR_TOL(exp, real, tol) assert_dbl_near(exp, real, tol, __FILE__, __LINE__)
 #define ASSERT_DBL_NEAR(exp, real) assert_dbl_near(exp, real, DBL_EPSILON, __FILE__, __LINE__)
@@ -212,6 +218,22 @@ inline static void assert_not_null(void *real, const char *caller, int line)
     }
 }
 
+inline static void assert_not_inf(double real, char const *caller, int line)
+{
+    if (isinf(real))
+    {
+        unit_error("%s: %d unexpected INFINITY", caller, line);
+    }
+}
+
+inline static void assert_inf(double real, char const *caller, int line)
+{
+    if (!isinf(real))
+    {
+        unit_error("%s: %d expected INFINITY, got %0.3e", real, caller, line);
+    }
+}
+
 inline static void assert_not_nan(double real, char const *caller, int line)
 {
     if (isnan(real))
@@ -236,11 +258,21 @@ inline static void assert_dbl_near(double exp, double real, double tol, char con
         {
             unit_error("%s:%d expected NAN, got %0.3e", caller, line, real);
         }
-        return;
     }
     else if (isnan(real))
     {
         unit_error("%s:%d expected %0.3e, got NAN", caller, line, exp);
+    }
+    if (isinf(exp))
+    {
+        if (!isinf(real))
+        {
+            unit_error("%s:%d expected INFINITY, got %0.3e", caller, line, real);
+        }
+    }
+    else if (isinf(real))
+    {
+        unit_error("%s:%d expected %0.3e, got INFINITY", caller, line, exp);
     }
     double diff = exp - real;
     tol += DBL_EPSILON;

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -170,6 +170,10 @@ inline static void assert_dbl_near(double exp, double real, double tol, char con
 #define ASSERT_DBL_NEAR_TOL(exp, real, tol) assert_dbl_near(exp, real, tol, __FILE__, __LINE__)
 #define ASSERT_DBL_NEAR(exp, real) assert_dbl_near(exp, real, DBL_EPSILON, __FILE__, __LINE__)
 
+inline static void assert_dbl_array_near(double *exp, double *real, size_t n, double tol, char const *caller, int line);
+#define ASSERT_DBL_ARRAY_NEAR_TOL(exp, real, n, tol) assert_dbl_array_near(exp, real, n, tol, __FILE__, __LINE__)
+#define ASSERT_DBL_ARRAY_NEAR(exp, real, n) assert_dbl_array_near(exp, real, n, DBL_EPSILON, __FILE__, __LINE__)
+
 inline static void assert_equal(intmax_t exp, intmax_t real, char const *caller, int line)
 {
     if (exp != real)
@@ -280,5 +284,13 @@ inline static void assert_dbl_near(double exp, double real, double tol, char con
     if (absdiff > tol)
     {
         unit_error("%s:%d expected %0.3e, got %0.3e (diff %0.3e, tol %0.3e)", caller, line, exp, real, diff, tol);
+    }
+}
+
+inline static void assert_dbl_array_near(double *exp, double *real, size_t n, double tol, char const *caller, int line)
+{
+    for (size_t i = 0; i < n; ++i)
+    {
+        assert_dbl_near(exp[i], real[i], tol, caller, line);
     }
 }

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <float.h>
 #include <inttypes.h>
+#include <math.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -153,6 +154,12 @@ inline static void assert_null(void *real, char const *caller, int line);
 inline static void assert_not_null(void *real, char const *caller, int line);
 #define ASSERT_NOT_NULL(real) assert_not_null(real, __FILE__, __LINE__)
 
+inline static void assert_not_nan(double real, char const *caller, int line);
+#define ASSERT_NOT_NAN(real) assert_not_nan(real, __FILE__, __LINE__);
+
+inline static void assert_nan(double real, char const *caller, int line);
+#define ASSERT_NAN(real) assert_nan(real, __FILE__, __LINE__);
+
 inline static void assert_dbl_near(double exp, double real, double tol, char const *caller, int line);
 #define ASSERT_DBL_NEAR_TOL(exp, real, tol) assert_dbl_near(exp, real, tol, __FILE__, __LINE__)
 #define ASSERT_DBL_NEAR(exp, real) assert_dbl_near(exp, real, DBL_EPSILON, __FILE__, __LINE__)
@@ -205,8 +212,36 @@ inline static void assert_not_null(void *real, const char *caller, int line)
     }
 }
 
+inline static void assert_not_nan(double real, char const *caller, int line)
+{
+    if (isnan(real))
+    {
+        unit_error("%s: %d unexpected NAN", caller, line);
+    }
+}
+
+inline static void assert_nan(double real, char const *caller, int line)
+{
+    if (!isnan(real))
+    {
+        unit_error("%s: %d expected NAN, got %0.3e", real, caller, line);
+    }
+}
+
 inline static void assert_dbl_near(double exp, double real, double tol, char const *caller, int line)
 {
+    if (isnan(exp))
+    {
+        if (!isnan(real))
+        {
+            unit_error("%s:%d expected NAN, got %0.3e", caller, line, real);
+        }
+        return;
+    }
+    else if (isnan(real))
+    {
+        unit_error("%s:%d expected %0.3e, got NAN", caller, line, exp);
+    }
     double diff = exp - real;
     tol += DBL_EPSILON;
     double absdiff = (diff < 0.) ? -diff : diff;

--- a/test/unittests/active_info.c
+++ b/test/unittests/active_info.c
@@ -9,7 +9,7 @@
 UNIT(ActiveInfoSeriesNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_active_info(NULL, 1, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_active_info(NULL, 1, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -18,7 +18,7 @@ UNIT(ActiveInfoSeriesNoInits)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_active_info(series, 0, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_active_info(series, 0, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -31,7 +31,7 @@ UNIT(ActiveInfoSeriesTooShort)
     for (size_t i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_active_info(series, 1, i, 2, 2, &err)));
+        ASSERT_NAN(inform_active_info(series, 1, i, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -44,7 +44,7 @@ UNIT(ActiveInfoHistoryTooLong)
     for (size_t i = 2; i < 4; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_active_info(series, 1, 2, 2, i, &err)));
+        ASSERT_NAN(inform_active_info(series, 1, 2, 2, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EKLONG, err);
     }
@@ -54,7 +54,7 @@ UNIT(ActiveInfoZeroHistory)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_active_info(series, 1, 2, 2, 0, &err)));
+    ASSERT_NAN(inform_active_info(series, 1, 2, 2, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -66,7 +66,7 @@ UNIT(ActiveInfoInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_active_info(series, 1, 2, i, 2, &err)));
+        ASSERT_NAN(inform_active_info(series, 1, 2, i, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -76,7 +76,7 @@ UNIT(ActiveInfoNegativeState)
 {
     int const series[] = {-1,1,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_active_info(series, 1, 8, 3, 2, &err)));
+    ASSERT_NAN(inform_active_info(series, 1, 8, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -85,7 +85,7 @@ UNIT(ActiveInfoBadState)
 {
     int const series[] = {1,2,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_active_info(series, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_active_info(series, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/block_entropy.c
+++ b/test/unittests/block_entropy.c
@@ -9,7 +9,7 @@
 UNIT(BlockEntropyNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_block_entropy(NULL, 1, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_block_entropy(NULL, 1, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -18,7 +18,7 @@ UNIT(BlockEntropyNoInits)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_block_entropy(series, 0, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_block_entropy(series, 0, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -31,7 +31,7 @@ UNIT(BlockEntropySeriesTooShort)
     for (size_t i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_block_entropy(series, 1, i, 2, 2, &err)));
+        ASSERT_NAN(inform_block_entropy(series, 1, i, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -44,7 +44,7 @@ UNIT(BlockEntropyHistoryTooLong)
     for (size_t i = 2; i < 4; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_block_entropy(series, 1, 2, 2, i, &err)));
+        ASSERT_NAN(inform_block_entropy(series, 1, 2, 2, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EKLONG, err);
     }
@@ -54,7 +54,7 @@ UNIT(BlockEntropyZeroHistory)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_block_entropy(series, 1, 2, 2, 0, &err)));
+    ASSERT_NAN(inform_block_entropy(series, 1, 2, 2, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -66,7 +66,7 @@ UNIT(BlockEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_block_entropy(series, 1, 2, i, 2, &err)));
+        ASSERT_NAN(inform_block_entropy(series, 1, 2, i, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -76,7 +76,7 @@ UNIT(BlockEntropyNegativeState)
 {
     int const series[] = {-1,1,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_block_entropy(series, 1, 8, 3, 2, &err)));
+    ASSERT_NAN(inform_block_entropy(series, 1, 8, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -85,7 +85,7 @@ UNIT(BlockEntropyBadState)
 {
     int const series[] = {1,2,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_block_entropy(series, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_block_entropy(series, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/conditional_entropy.c
+++ b/test/unittests/conditional_entropy.c
@@ -9,12 +9,12 @@
 UNIT(ConditionalEntropyNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(NULL, NULL, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy(NULL, NULL, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy((int[]){0,0,1}, NULL, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy((int[]){0,0,1}, NULL, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -23,7 +23,7 @@ UNIT(ConditionalEntropySeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 0, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy(xs, xs, 0, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -35,12 +35,12 @@ UNIT(ConditionalEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 8, i, 2, &err)));
+        ASSERT_NAN(inform_conditional_entropy(xs, xs, 8, i, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
 
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_conditional_entropy(xs, xs, 8, 2, i, &err)));
+        ASSERT_NAN(inform_conditional_entropy(xs, xs, 8, 2, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -51,12 +51,12 @@ UNIT(ConditionalEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy(xs, ys, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(ys, xs, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy(ys, xs, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -66,12 +66,12 @@ UNIT(ConditionalEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy(xs, ys, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_conditional_entropy(xs, ys, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_conditional_entropy(xs, ys, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/cross_entropy.c
+++ b/test/unittests/cross_entropy.c
@@ -9,12 +9,12 @@
 UNIT(CrossEntropyNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy(NULL, NULL, 3, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy(NULL, NULL, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy((int[]){0,0,1}, NULL, 3, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy((int[]){0,0,1}, NULL, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -23,7 +23,7 @@ UNIT(CrossEntropySeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy(xs, xs, 0, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy(xs, xs, 0, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -35,7 +35,7 @@ UNIT(CrossEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_cross_entropy(xs, xs, 8, i, &err)));
+        ASSERT_NAN(inform_cross_entropy(xs, xs, 8, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -46,12 +46,12 @@ UNIT(CrossEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy(xs, ys, 8, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy(xs, ys, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy(ys, xs, 8, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy(ys, xs, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -61,12 +61,12 @@ UNIT(CrossEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy(xs, ys, 8, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy(xs, ys, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_cross_entropy(xs, ys, 8, 2, &err)));
+    ASSERT_NAN(inform_cross_entropy(xs, ys, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -77,77 +77,66 @@ UNIT(CrossEntropy)
 
     double got = inform_cross_entropy((int[]){0,0,1,1,1,1,0,0,0},
         (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR((log2(3)-5.0/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){1,0,0,1,0,0,1,0,0},
         (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(((18*log2(3)-6*log2(5)-6)/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,0,0,0,1,1,1,1},
         (int[]){1,1,1,1,0,0,0,0}, 8, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(1.000000, got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,0,1,1,1,1,0,0,0},
         (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(((18*log2(3)-4*log2(5)-10)/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){1,1,0,1,0,1,1,1,0},
         (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(((18*log2(3)-6*log2(5)-6)/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,0,0,0,0,0,0,0,0},
         (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(log2(3), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){1,1,1,1,0,0,0,0,1},
         (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR((log2(3)-5.0/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){1,1,0,0,1,1,0,0,1},
         (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR((log2(3)-5.0/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,1,0,1,0,1,0,1},
         (int[]){0,2,0,2,0,2,0,2}, 8, 3, &err);
-    ASSERT_TRUE(isinf(got));
+    ASSERT_INF(got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1},
             (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(log2(3), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,0,1,1,2,1,1,0,0},
         (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, &err);
-    ASSERT_TRUE(isinf(got));
+    ASSERT_INF(got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){0,1,0,0,1,0,0,1,0},
         (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR((log2(3)-6.0/9), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     got = inform_cross_entropy((int[]){1,0,0,1,0,0,1,0},
         (int[]){2,0,1,2,0,1,2,0}, 8, 3, &err);
-    ASSERT_FALSE(isnan(got));
     ASSERT_DBL_NEAR(((24 - 5*log2(3) - 3)/8), got);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }

--- a/test/unittests/effective_info.c
+++ b/test/unittests/effective_info.c
@@ -9,7 +9,7 @@
 UNIT(EffectiveInfoNullTPM)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_effective_info(NULL, NULL, 0, &err)));
+    ASSERT_NAN(inform_effective_info(NULL, NULL, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETPM, err);
 }
@@ -18,7 +18,7 @@ UNIT(EffectiveInfoZeroSize)
 {
     double tpm[4] = {0.0, 1.0, 0.0, 0.0};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_effective_info(tpm, NULL, 0, &err)));
+    ASSERT_NAN(inform_effective_info(tpm, NULL, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESIZE, err);
 }
@@ -27,7 +27,7 @@ UNIT(EffectiveInfoZeroRowTPM)
 {
     double tpm[4] = {0.0, 1.0, 0.0, 0.0};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_effective_info(tpm, NULL, 2, &err)));
+    ASSERT_NAN(inform_effective_info(tpm, NULL, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETPM, err);
 }
@@ -36,7 +36,7 @@ UNIT(EffectiveInfoNegativeProbabilitiesTPM)
 {
     double tpm[4] = {-0.5, 1.0, 0.5, 0.5};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_effective_info(tpm, NULL, 2, &err)));
+    ASSERT_NAN(inform_effective_info(tpm, NULL, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETPM, err);
 }
@@ -46,13 +46,13 @@ UNIT(EffectiveInfoUnNormalizedRowTPM)
     inform_error err = INFORM_SUCCESS;
     {
         double tpm[4] = {0.5, 0.5, 0.5, 0.25};
-        ASSERT_TRUE(isnan(inform_effective_info(tpm, NULL, 2, &err)));
+        ASSERT_NAN(inform_effective_info(tpm, NULL, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ETPM, err);
     }
     {
         double tpm[4] = {0.5, 0.5, 0.5, 0.75};
-        ASSERT_TRUE(isnan(inform_effective_info(tpm, NULL, 2, &err)));
+        ASSERT_NAN(inform_effective_info(tpm, NULL, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ETPM, err);
     }
@@ -63,7 +63,7 @@ UNIT(EffectiveInfoZeroIntervention)
     double tpm[4] = {0.25, 0.75, 0.3, 0.7};
     double inter[2] = {0.0, 0.0};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_effective_info(tpm, inter, 2, &err)));
+    ASSERT_NAN(inform_effective_info(tpm, inter, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EDIST, err);
 }
@@ -73,7 +73,7 @@ UNIT(EffectiveInfoNegativeProbabilitiesIntervention)
     double tpm[4] = {0.25, 0.75, 0.3, 0.7};
     double inter[2] = {0.0, -0.2};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_effective_info(tpm, inter, 2, &err)));
+    ASSERT_NAN(inform_effective_info(tpm, inter, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EDIST, err);
 }
@@ -84,13 +84,13 @@ UNIT(EffectiveInfoUnNormalizedIntervention)
     double tpm[4] = {0.25, 0.75, 0.3, 0.7};
     {
         double inter[2] = {0.5, 0.25};
-        ASSERT_TRUE(isnan(inform_effective_info(tpm, inter, 2, &err)));
+        ASSERT_NAN(inform_effective_info(tpm, inter, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EDIST, err);
     }
     {
         double inter[2] = {0.5, 0.75};
-        ASSERT_TRUE(isnan(inform_effective_info(tpm, inter, 2, &err)));
+        ASSERT_NAN(inform_effective_info(tpm, inter, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EDIST, err);
     }

--- a/test/unittests/entropy_rate.c
+++ b/test/unittests/entropy_rate.c
@@ -9,7 +9,7 @@
 UNIT(EntropyRateNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_entropy_rate(NULL, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_entropy_rate(NULL, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -18,7 +18,7 @@ UNIT(EntropyRateNoInits)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_entropy_rate(series, 0, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_entropy_rate(series, 0, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -31,7 +31,7 @@ UNIT(EntropyRateSeriesTooShort)
     for (size_t i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_entropy_rate(series, 1, i, 2, 2, &err)));
+        ASSERT_NAN(inform_entropy_rate(series, 1, i, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -44,7 +44,7 @@ UNIT(EntropyRateInvalidBase)
     
     for (int i = 0; i < 2; ++i)
     {
-        ASSERT_TRUE(isnan(inform_entropy_rate(series, 1, 2, i, 2, &err)));
+        ASSERT_NAN(inform_entropy_rate(series, 1, 2, i, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -55,7 +55,7 @@ UNIT(EntropyRateZeroHistory)
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
     
-    ASSERT_TRUE(isnan(inform_entropy_rate(series, 1, 2, 2, 0, &err)));
+    ASSERT_NAN(inform_entropy_rate(series, 1, 2, 2, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -68,7 +68,7 @@ UNIT(EntropyRateHistoryTooLong)
     for (size_t i = 2; i < 4; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_entropy_rate(series, 1, 2, 2, i, &err)));
+        ASSERT_NAN(inform_entropy_rate(series, 1, 2, 2, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EKLONG, err);
     }
@@ -78,7 +78,7 @@ UNIT(EntropyRateNegativeState)
 {
     int const series[] = {-1,1,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_entropy_rate(series, 1, 8, 3, 2, &err)));
+    ASSERT_NAN(inform_entropy_rate(series, 1, 8, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -87,7 +87,7 @@ UNIT(EntropyRateBadState)
 {
     int const series[] = {1,2,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_entropy_rate(series, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_entropy_rate(series, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/excess_entropy.c
+++ b/test/unittests/excess_entropy.c
@@ -9,7 +9,7 @@
 UNIT(ExcessEntropySeriesNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_excess_entropy(NULL, 1, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_excess_entropy(NULL, 1, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -18,7 +18,7 @@ UNIT(ExcessEntropySeriesNoInits)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_excess_entropy(series, 0, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_excess_entropy(series, 0, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -31,7 +31,7 @@ UNIT(ExcessEntropySeriesTooShort)
     for (size_t i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_excess_entropy(series, 1, i, 2, 2, &err)));
+        ASSERT_NAN(inform_excess_entropy(series, 1, i, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -41,7 +41,7 @@ UNIT(ExcessEntropyZeroHistory)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_excess_entropy(series, 1, 2, 2, 0, &err)));
+    ASSERT_NAN(inform_excess_entropy(series, 1, 2, 2, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -55,14 +55,14 @@ UNIT(ExcessEntropyKTooLong)
         if (2 * i >= 3)
         {
             err = INFORM_SUCCESS;
-            ASSERT_TRUE(isnan(inform_excess_entropy(series, 1, 3, 2, i, &err)));
+            ASSERT_NAN(inform_excess_entropy(series, 1, 3, 2, i, &err));
             ASSERT_TRUE(inform_failed(&err));
             ASSERT_EQUAL(INFORM_EKLONG, err);
         }
         else
         {
             err = INFORM_SUCCESS;
-            ASSERT_FALSE(isnan(inform_excess_entropy(series, 1, 3, 2, i, &err)));
+            ASSERT_NOT_NAN(inform_excess_entropy(series, 1, 3, 2, i, &err));
             ASSERT_TRUE(inform_succeeded(&err)); 
         }
     }
@@ -75,7 +75,7 @@ UNIT(ExcessEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_excess_entropy(series, 1, 2, i, 2, &err)));
+        ASSERT_NAN(inform_excess_entropy(series, 1, 2, i, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -85,7 +85,7 @@ UNIT(ExcessEntropyNegativeState)
 {
     int const series[] = {-1,1,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_excess_entropy(series, 1, 8, 3, 2, &err)));
+    ASSERT_NAN(inform_excess_entropy(series, 1, 8, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -94,7 +94,7 @@ UNIT(ExcessEntropyBadState)
 {
     int const series[] = {1,2,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_excess_entropy(series, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_excess_entropy(series, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/mutual_info.c
+++ b/test/unittests/mutual_info.c
@@ -9,7 +9,7 @@
 UNIT(MutualInfoNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(NULL, 1, 3, (int[]){2,2}, &err)));
+    ASSERT_NAN(inform_mutual_info(NULL, 1, 3, (int[]){2,2}, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -17,7 +17,7 @@ UNIT(MutualInfoNULLSeries)
 UNIT(MutualInfoTooFewSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info((int[]){1,0,1}, 1, 3, (int[]){2,2}, &err)));
+    ASSERT_NAN(inform_mutual_info((int[]){1,0,1}, 1, 3, (int[]){2,2}, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOSOURCES, err);
 }
@@ -26,7 +26,7 @@ UNIT(MutualInfoSeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 0, (int[]){2,2}, &err)));
+    ASSERT_NAN(inform_mutual_info(xs, 2, 0, (int[]){2,2}, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -38,12 +38,12 @@ UNIT(MutualInfoInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 4, (int[]){i,2}, &err)));
+        ASSERT_NAN(inform_mutual_info(xs, 2, 4, (int[]){i,2}, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
 
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 4, (int[]){2,i}, &err)));
+        ASSERT_NAN(inform_mutual_info(xs, 2, 4, (int[]){2,i}, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -54,14 +54,14 @@ UNIT(MutualInfoNegativeState)
     {
         int const xs[] = {1,1,0,0,-1,0,0,1,1,1,0,0,1,0,0,1};
         inform_error err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err)));
+        ASSERT_NAN(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ENEGSTATE, err);
     }
     {
         int const xs[] = {1,1,0,0,1,0,0,1,1,1,0,0,-1,0,0,1};
         inform_error err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err)));
+        ASSERT_NAN(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ENEGSTATE, err);
     }
@@ -72,14 +72,14 @@ UNIT(MutualInfoBadState)
     {
         int const xs[] = {1,2,0,0,1,0,0,1,1,1,0,0,1,0,0,1};
         inform_error err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err)));
+        ASSERT_NAN(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBADSTATE, err);
     }
     {
         int const xs[] = {1,1,0,0,1,0,0,1,1,1,0,2,1,0,0,1};
         inform_error err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err)));
+        ASSERT_NAN(inform_mutual_info(xs, 2, 8, (int[]){2,2}, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBADSTATE, err);
     }

--- a/test/unittests/predictive_info.c
+++ b/test/unittests/predictive_info.c
@@ -9,7 +9,7 @@
 UNIT(PredictiveInfoSeriesNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_predictive_info(NULL, 1, 3, 2, 2, 2, &err)));
+    ASSERT_NAN(inform_predictive_info(NULL, 1, 3, 2, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -18,7 +18,7 @@ UNIT(PredictiveInfoSeriesNoInits)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_predictive_info(series, 0, 3, 2, 2, 2, &err)));
+    ASSERT_NAN(inform_predictive_info(series, 0, 3, 2, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -31,7 +31,7 @@ UNIT(PredictiveInfoSeriesTooShort)
     for (size_t i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_predictive_info(series, 1, i, 2, 2, 2, &err)));
+        ASSERT_NAN(inform_predictive_info(series, 1, i, 2, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -41,7 +41,7 @@ UNIT(PredictiveInfoZeroHistory)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_predictive_info(series, 1, 2, 2, 0, 2, &err)));
+    ASSERT_NAN(inform_predictive_info(series, 1, 2, 2, 0, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -50,7 +50,7 @@ UNIT(PredictiveInfoZeroFuture)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_predictive_info(series, 1, 2, 2, 2, 0, &err)));
+    ASSERT_NAN(inform_predictive_info(series, 1, 2, 2, 2, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -66,14 +66,14 @@ UNIT(PredictiveInfoKTooLong)
             if (i + j >= 3)
             {
                 err = INFORM_SUCCESS;
-                ASSERT_TRUE(isnan(inform_predictive_info(series, 1, 3, 2, i, j, &err)));
+                ASSERT_NAN(inform_predictive_info(series, 1, 3, 2, i, j, &err));
                 ASSERT_TRUE(inform_failed(&err));
                 ASSERT_EQUAL(INFORM_EKLONG, err);
             }
             else
             {
                 err = INFORM_SUCCESS;
-                ASSERT_FALSE(isnan(inform_predictive_info(series, 1, 3, 2, i, j, &err)));
+                ASSERT_NOT_NAN(inform_predictive_info(series, 1, 3, 2, i, j, &err));
                 ASSERT_TRUE(inform_succeeded(&err)); 
             }
         }
@@ -87,7 +87,7 @@ UNIT(PredictiveInfoInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_predictive_info(series, 1, 2, i, 2, 2, &err)));
+        ASSERT_NAN(inform_predictive_info(series, 1, 2, i, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -97,7 +97,7 @@ UNIT(PredictiveInfoNegativeState)
 {
     int const series[] = {-1,1,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_predictive_info(series, 1, 8, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_predictive_info(series, 1, 8, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -106,7 +106,7 @@ UNIT(PredictiveInfoBadState)
 {
     int const series[] = {1,2,0,0,1,0,0,1};
     inform_error err;
-    ASSERT_TRUE(isnan(inform_predictive_info(series, 1, 8, 2, 2, 2, &err)));
+    ASSERT_NAN(inform_predictive_info(series, 1, 8, 2, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/relative_entropy.c
+++ b/test/unittests/relative_entropy.c
@@ -9,12 +9,12 @@
 UNIT(RelativeEntropyNULLSeries)
 {
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(NULL, NULL, 3, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy(NULL, NULL, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,0,1}, NULL, 3, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy((int[]){0,0,1}, NULL, 3, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -23,7 +23,7 @@ UNIT(RelativeEntropySeriesTooShort)
 {
     int const xs[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, xs, 0, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy(xs, xs, 0, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
 }
@@ -35,7 +35,7 @@ UNIT(RelativeEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_relative_entropy(xs, xs, 8, i, &err)));
+        ASSERT_NAN(inform_relative_entropy(xs, xs, 8, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -46,12 +46,12 @@ UNIT(RelativeEntropyNegativeState)
     int const xs[] = {1,1,0,0,-1,0,0,1};
     int const ys[] = {1,1,0,0, 1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy(xs, ys, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(ys, xs, 8, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy(ys, xs, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -61,12 +61,12 @@ UNIT(RelativeEntropyBadState)
     int const xs[] = {1,2,0,0,1,0,0,1};
     int const ys[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy(xs, ys, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_relative_entropy(xs, ys, 8, 2, &err)));
+    ASSERT_NAN(inform_relative_entropy(xs, ys, 8, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }
@@ -107,8 +107,8 @@ UNIT(RelativeEntropy)
         (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,1,0,1,0,1,0,1},
-        (int[]){0,2,0,2,0,2,0,2}, 8, 3, &err)));
+    ASSERT_NAN(inform_relative_entropy((int[]){0,1,0,1,0,1,0,1},
+        (int[]){0,2,0,2,0,2,0,2}, 8, 3, &err));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.584963,
@@ -116,8 +116,8 @@ UNIT(RelativeEntropy)
             (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, &err), 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
-    ASSERT_TRUE(isnan(inform_relative_entropy((int[]){0,0,1,1,2,1,1,0,0},
-        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, &err)));
+    ASSERT_NAN(inform_relative_entropy((int[]){0,0,1,1,2,1,1,0,0},
+        (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, &err));
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     ASSERT_DBL_NEAR_TOL(0.000000, inform_relative_entropy((int[]){0,1,0,0,1,0,0,1,0},
@@ -210,34 +210,6 @@ UNIT(LocalRelativeEntropyAllocatesOutput)
     free(re);
 }
 
-bool dbl_near_tol_arrays(double const *xs, double const *ys, size_t n, double tol)
-{
-    for (size_t i = 0; i < n; ++i)
-    {
-        if (isnan(xs[i]) && isnan(ys[i]))
-        {
-            continue;
-        }
-        else if (isinf(xs[i]) && isinf(ys[i]))
-        {
-            continue;
-        }
-        else if (isnan(xs[i]) || isnan(ys[i]))
-        {
-            return false;
-        }
-        else if (isinf(xs[i]) || isinf(ys[i]))
-        {
-            return false;
-        }
-        else if (fabs(xs[i] - ys[i]) > tol)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
 UNIT(LocalRelativeEntropy)
 {
     inform_error err = INFORM_SUCCESS;
@@ -245,55 +217,55 @@ UNIT(LocalRelativeEntropy)
     double re_3[3];
 
     inform_local_relative_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){-0.263034, 0.415037}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){-0.263034, 0.415037}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){1,0,0,1,0,0,1,0,0}, (int[]){0,0,1,1,1,1,0,0,0}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.263034, -0.415037}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.263034, -0.415037}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,0,0,0,1,1,1,1}, (int[]){1,1,1,1,0,0,0,0}, 8, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.000000, 0.000000}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.000000, 0.000000}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,0,1,1,1,1,0,0,0}, (int[]){1,1,0,0,0,0,1,1,1}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.321928, -0.321928}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.321928, -0.321928}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){1,1,0,1,0,1,1,1,0}, (int[]){1,1,0,0,0,1,0,1,1}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){-0.415037, 0.263034}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){-0.415037, 0.263034}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,0,0,0,0,0,0,0,0}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){1.584963, -INFINITY}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){1.584963, -INFINITY}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){1,1,1,1,0,0,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.415037, -0.263034}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.415037, -0.263034}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){1,1,0,0,1,1,0,0,1}, (int[]){1,1,1,0,0,0,1,1,1}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.415037, -0.263034}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.415037, -0.263034}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,1,0,1,0,1,0,1}, (int[]){0,2,0,2,0,2,0,2}, 8, 3, re_3, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.000000, INFINITY, -INFINITY}, re_3, 3, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.000000, INFINITY, -INFINITY}), re_3, 3, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,0,0,0,0,0,1,1,1,1,1,1}, (int[]){0,0,0,0,1,1,1,1,2,2,2,2}, 12, 3, re_3, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.584963, 0.584963, -INFINITY}, re_3, 3, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.584963, 0.584963, -INFINITY}), re_3, 3, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,0,1,1,2,1,1,0,0}, (int[]){0,0,0,1,1,1,0,0,0}, 9, 3, re_3, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){-0.584963, 0.415037, INFINITY}, re_3, 3, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){-0.584963, 0.415037, INFINITY}), re_3, 3, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){0,1,0,0,1,0,0,1,0}, (int[]){1,0,0,1,0,0,1,0,0}, 9, 2, re_2, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.000000, 0.000000, -INFINITY}, re_2, 2, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.000000, 0.000000, -INFINITY}), re_2, 2, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 
     inform_local_relative_entropy((int[]){1,0,0,1,0,0,1,0}, (int[]){2,0,1,2,0,1,2,0}, 8, 3, re_3, &err);
-    ASSERT_TRUE(dbl_near_tol_arrays((double[]){0.736966, 0.584963, -INFINITY}, re_3, 3, 1e-6));
+    ASSERT_DBL_ARRAY_NEAR_TOL(((double[]){0.736966, 0.584963, -INFINITY}), re_3, 3, 1e-6);
     ASSERT_EQUAL(INFORM_SUCCESS, err);
 }
 

--- a/test/unittests/separable_info.c
+++ b/test/unittests/separable_info.c
@@ -12,13 +12,13 @@ UNIT(SeparableInformationNULLSeries)
 
     inform_error err = INFORM_SUCCESS;
     double si = inform_separable_info(NULL, series, 1, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
     si = inform_separable_info(series, NULL, 1, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -29,7 +29,7 @@ UNIT(SeparableInformationNoSources)
 
     inform_error err = INFORM_SUCCESS;
     double si = inform_separable_info(series, series, 0, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOSOURCES, err);
 }
@@ -40,7 +40,7 @@ UNIT(SeparableInformationNoInits)
 
     inform_error err = INFORM_SUCCESS;
     double si = inform_separable_info(series, series, 1, 0, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -53,7 +53,7 @@ UNIT(SeparableInformationSeriesTooShort)
     {
         err = INFORM_SUCCESS;
         double si = inform_separable_info(series, series, 1, 1, i, 2, 2, &err);
-        ASSERT_TRUE(isnan(si));
+        ASSERT_NAN(si);
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -67,7 +67,7 @@ UNIT(SeparableInformationHistoryTooLong)
     {
         err = INFORM_SUCCESS;
         double si = inform_separable_info(series, series, 1, 1, 2, 2, i, &err);
-        ASSERT_TRUE(isnan(si));
+        ASSERT_NAN(si);
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EKLONG, err);
     }
@@ -78,7 +78,7 @@ UNIT(SeparableInformationZeroHistory)
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
     double si = inform_separable_info(series, series, 1, 1, 2, 2, 0, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -91,7 +91,7 @@ UNIT(SeparableInformationInvalidBase)
     {
         err = INFORM_SUCCESS;
         double si = inform_separable_info(series, series, 1, 1, 2, i, 2, &err);
-        ASSERT_TRUE(isnan(si));
+        ASSERT_NAN(si);
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -104,13 +104,13 @@ UNIT(SeparableInformationNegativeState)
     inform_error err = INFORM_SUCCESS;
 
     double si = inform_separable_info(seriesA, seriesB, 1, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
     si = inform_separable_info(seriesB, seriesA, 1, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -122,13 +122,13 @@ UNIT(SeparableInformationBadState)
     inform_error err = INFORM_SUCCESS;
 
     double si = inform_separable_info(seriesA, seriesB, 1, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
     si = inform_separable_info(seriesB, seriesA, 1, 1, 8, 2, 2, &err);
-    ASSERT_TRUE(isnan(si));
+    ASSERT_NAN(si);
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }

--- a/test/unittests/shannon/multivariate.c
+++ b/test/unittests/shannon/multivariate.c
@@ -37,20 +37,22 @@ UNIT(ShannonMultiPointwiseMutualInformationIndependent)
         {
             for (size_t k = 0; k < inform_dist_size(zs); ++k)
             {
-                ASSERT_DBL_NEAR_TOL(0.000000,
+                size_t joint_event = k+12*(j+12*i);
+                double expect = inform_dist_prob(dist, joint_event) ? 0 : NAN;
+                ASSERT_DBL_NEAR_TOL(expect,
                     inform_shannon_multi_pmi(dist,
                         (inform_dist const *[3]){xs, ys, zs}, 3,
-                        k+12*(j+12*i), (size_t[3]){i, j, k}, 0.5),
+                        joint_event, (size_t[3]){i, j, k}, 0.5),
                     1e-6);
-                ASSERT_DBL_NEAR_TOL(0.000000,
+                ASSERT_DBL_NEAR_TOL(expect,
                     inform_shannon_multi_pmi(dist,
                         (inform_dist const *[3]){xs, ys, zs}, 3,
-                        k+12*(j+12*i), (size_t[3]){i, j, k}, 2),
+                        joint_event, (size_t[3]){i, j, k}, 2),
                     1e-6);
-                ASSERT_DBL_NEAR_TOL(0.000000,
+                ASSERT_DBL_NEAR_TOL(expect,
                     inform_shannon_multi_pmi(dist,
                         (inform_dist const *[3]){xs, ys, zs}, 3,
-                        k+12*(j+12*i), (size_t[3]){i, j, k}, 3),
+                        joint_event, (size_t[3]){i, j, k}, 3),
                     1e-6);
             }
         }

--- a/test/unittests/shannon/univariate.c
+++ b/test/unittests/shannon/univariate.c
@@ -10,10 +10,10 @@
 UNIT(ShannonUniInvalidDistribution)
 {
     inform_dist *dist = NULL;
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, 2)));
+    ASSERT_NAN(inform_shannon_entropy(dist, 2));
 
     dist = inform_dist_alloc(5);
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, 2)));
+    ASSERT_NAN(inform_shannon_entropy(dist, 2));
     inform_dist_free(dist);
 }
 
@@ -21,8 +21,8 @@ UNIT(ShannonUniDeltaFunction)
 {
     inform_dist *dist = inform_dist_alloc(5);
     inform_dist_fill(dist, 0, 1, 0, 0, 0);
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_NAN(inform_shannon_entropy(dist, -1.0));
+    ASSERT_NAN(inform_shannon_entropy(dist, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 1.5), 1e-6);
@@ -37,8 +37,8 @@ UNIT(ShannonUniUniform)
     inform_dist *dist = inform_dist_alloc(5);
     inform_dist_fill(dist, 1, 1, 1, 1, 1);
 
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_NAN(inform_shannon_entropy(dist, -1.0));
+    ASSERT_NAN(inform_shannon_entropy(dist, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(-2.321928, inform_shannon_entropy(dist, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(3.969362, inform_shannon_entropy(dist, 1.5), 1e-6);
@@ -53,8 +53,8 @@ UNIT(ShannonUniNonUniform)
     inform_dist *dist = inform_dist_alloc(2);
     inform_dist_fill(dist, 2, 1);
 
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_NAN(inform_shannon_entropy(dist, -1.0));
+    ASSERT_NAN(inform_shannon_entropy(dist, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(-0.918295, inform_shannon_entropy(dist, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(1.569837, inform_shannon_entropy(dist, 1.5), 1e-6);
@@ -65,8 +65,8 @@ UNIT(ShannonUniNonUniform)
     dist = inform_dist_realloc(dist, 3);
     inform_dist_fill(dist, 1, 1, 0);
 
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_NAN(inform_shannon_entropy(dist, -1.0));
+    ASSERT_NAN(inform_shannon_entropy(dist, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(-1.000000, inform_shannon_entropy(dist, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(1.709511, inform_shannon_entropy(dist, 1.5), 1e-6);
@@ -77,8 +77,8 @@ UNIT(ShannonUniNonUniform)
     inform_dist_fill(dist, 2, 2, 1);
     ASSERT_DBL_NEAR_TOL(1.521928, inform_shannon_entropy(dist, 2), 1e-6);
 
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_entropy(dist, -0.5)));
+    ASSERT_NAN(inform_shannon_entropy(dist, -1.0));
+    ASSERT_NAN(inform_shannon_entropy(dist, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_entropy(dist, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(-1.521928, inform_shannon_entropy(dist, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(2.601753, inform_shannon_entropy(dist, 1.5), 1e-6);
@@ -107,8 +107,8 @@ UNIT(ShannonUniMutualInformationIndependent)
                     inform_dist_get(xs, i) * inform_dist_get(ys, j));
         }
     }
-    ASSERT_TRUE(isnan(inform_shannon_mi(dist, xs, ys, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_mi(dist, xs, ys, -0.5)));
+    ASSERT_NAN(inform_shannon_mi(dist, xs, ys, -1.0));
+    ASSERT_NAN(inform_shannon_mi(dist, xs, ys, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_mi(dist, xs, ys, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_mi(dist, xs, ys, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_mi(dist, xs, ys, 1.5), 1e-6);
@@ -131,8 +131,8 @@ UNIT(ShannonUniMutualInformationDependent)
     inform_dist *ys = inform_dist_alloc(2);
     inform_dist_fill(ys, 25, 75);
 
-    ASSERT_TRUE(isnan(inform_shannon_mi(dist, xs, ys, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_mi(dist, xs, ys, -0.5)));
+    ASSERT_NAN(inform_shannon_mi(dist, xs, ys, -1.0));
+    ASSERT_NAN(inform_shannon_mi(dist, xs, ys, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_mi(dist, xs, ys, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(-0.214171, inform_shannon_mi(dist, xs, ys, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.366128, inform_shannon_mi(dist, xs, ys, 1.5), 1e-6);
@@ -147,15 +147,15 @@ UNIT(ShannonUniMutualInformationDependent)
 UNIT(ShannonUniSelfInformationInvalidDist)
 {
     inform_dist *dist = NULL;
-    ASSERT_TRUE(isnan(inform_shannon_si(dist, 0, 2)));
+    ASSERT_NAN(inform_shannon_si(dist, 0, 2));
 }
 
 UNIT(ShannonUniSelfInformationImposibleEvent)
 {
     inform_dist *dist = inform_dist_alloc(2);
     inform_dist_fill(dist, 1, 0);
-    ASSERT_FALSE(isinf(inform_shannon_si(dist, 0, 2)));
-    ASSERT_TRUE(isinf(inform_shannon_si(dist, 2, 2)));
+    ASSERT_NOT_INF(inform_shannon_si(dist, 0, 2));
+    ASSERT_INF(inform_shannon_si(dist, 2, 2));
     inform_dist_free(dist);
 }
 
@@ -172,7 +172,7 @@ UNIT(ShannonUniSelfInformationBase2)
 
     inform_dist_fill(dist, 2, 0);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_si(dist, 0, 2), 1e-6);
-    ASSERT_TRUE(isinf(inform_shannon_si(dist, 1, 2)));
+    ASSERT_INF(inform_shannon_si(dist, 1, 2));
 
     inform_dist_free(dist);
 }
@@ -245,19 +245,19 @@ UNIT(ShannonUniPointwiseMutualInformationDependent)
 UNIT(ShannonUniRelativeEntropyInvalidDistributions)
 {
     inform_dist *p = NULL, *q = NULL;
-    ASSERT_TRUE(isnan(inform_shannon_re(p, q, 2)));
+    ASSERT_NAN(inform_shannon_re(p, q, 2));
 
     p = inform_dist_alloc(5);
-    ASSERT_TRUE(isnan(inform_shannon_re(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_re(q, p, 2)));
+    ASSERT_NAN(inform_shannon_re(p, q, 2));
+    ASSERT_NAN(inform_shannon_re(q, p, 2));
 
     inform_dist_tick(p, 0);
-    ASSERT_TRUE(isnan(inform_shannon_re(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_re(q, p, 2)));
+    ASSERT_NAN(inform_shannon_re(p, q, 2));
+    ASSERT_NAN(inform_shannon_re(q, p, 2));
 
     q = inform_dist_alloc(5);
-    ASSERT_TRUE(isnan(inform_shannon_re(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_re(q, p, 2)));
+    ASSERT_NAN(inform_shannon_re(p, q, 2));
+    ASSERT_NAN(inform_shannon_re(q, p, 2));
 
     inform_dist_free(q);
     inform_dist_free(p);
@@ -271,8 +271,8 @@ UNIT(ShannonUniRelativeEntropyIncompatibleSizes)
     inform_dist_tick(p, 0);
     inform_dist_tick(q, 1);
 
-    ASSERT_TRUE(isnan(inform_shannon_re(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_re(q, p, 2)));
+    ASSERT_NAN(inform_shannon_re(p, q, 2));
+    ASSERT_NAN(inform_shannon_re(q, p, 2));
 
     inform_dist_free(q);
     inform_dist_free(p);
@@ -285,8 +285,8 @@ UNIT(ShannonUniRelativeEntropyUndefined)
     inform_dist_fill(p, 1, 1, 1, 1, 1);
     inform_dist_fill(q, 1, 1, 1, 2, 0);
 
-    ASSERT_TRUE(isnan(inform_shannon_re(p, q, 2)));
-    ASSERT_FALSE(isnan(inform_shannon_re(q, p, 2)));
+    ASSERT_NAN(inform_shannon_re(p, q, 2));
+    ASSERT_NOT_NAN(inform_shannon_re(q, p, 2));
 
     inform_dist_free(q);
     inform_dist_free(p);
@@ -297,8 +297,8 @@ UNIT(ShannonUniRelativeEntropySameDist)
     inform_dist *p = inform_dist_alloc(20);
     for (size_t i = 0; i < inform_dist_size(p); ++i)
         inform_dist_set(p, i, inform_random_int(0, 100));
-    ASSERT_TRUE(isnan(inform_shannon_re(p, p, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_re(p, p, -0.5)));
+    ASSERT_NAN(inform_shannon_re(p, p, -1.0));
+    ASSERT_NAN(inform_shannon_re(p, p, -0.5));
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_re(p, p, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_re(p, p, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(0.000000, inform_shannon_re(p, p, 1.5), 1e-6);
@@ -366,19 +366,19 @@ UNIT(ShannonUniRelativeEntropyDefined)
 UNIT(ShannonUniCrossEntropyInvalidDistributions)
 {
     inform_dist *p = NULL, *q = NULL;
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, q, 2)));
+    ASSERT_NAN(inform_shannon_cross(p, q, 2));
 
     p = inform_dist_alloc(5);
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_cross(q, p, 2)));
+    ASSERT_NAN(inform_shannon_cross(p, q, 2));
+    ASSERT_NAN(inform_shannon_cross(q, p, 2));
 
     inform_dist_tick(p, 0);
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_cross(q, p, 2)));
+    ASSERT_NAN(inform_shannon_cross(p, q, 2));
+    ASSERT_NAN(inform_shannon_cross(q, p, 2));
 
     q = inform_dist_alloc(5);
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_cross(q, p, 2)));
+    ASSERT_NAN(inform_shannon_cross(p, q, 2));
+    ASSERT_NAN(inform_shannon_cross(q, p, 2));
 
     inform_dist_free(q);
     inform_dist_free(p);
@@ -392,8 +392,8 @@ UNIT(ShannonUniCrossEntropyIncompatibleSizes)
     inform_dist_tick(p, 0);
     inform_dist_tick(q, 1);
 
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, q, 2)));
-    ASSERT_TRUE(isnan(inform_shannon_cross(q, p, 2)));
+    ASSERT_NAN(inform_shannon_cross(p, q, 2));
+    ASSERT_NAN(inform_shannon_cross(q, p, 2));
 
     inform_dist_free(q);
     inform_dist_free(p);
@@ -406,9 +406,9 @@ UNIT(ShannonUniCrossEntropyUndefined)
     inform_dist_fill(p, 1, 1, 1, 1, 1);
     inform_dist_fill(q, 1, 1, 1, 2, 0);
 
-    ASSERT_TRUE(isinf(inform_shannon_cross(p, q, 2)));
-    ASSERT_FALSE(isnan(inform_shannon_cross(q, p, 2)));
-    ASSERT_FALSE(isinf(inform_shannon_cross(q, p, 2)));
+    ASSERT_INF(inform_shannon_cross(p, q, 2));
+    ASSERT_NOT_NAN(inform_shannon_cross(q, p, 2));
+    ASSERT_NOT_INF(inform_shannon_cross(q, p, 2));
 
     inform_dist_free(q);
     inform_dist_free(p);
@@ -419,8 +419,8 @@ UNIT(ShannonUniCrossEntropySameDist)
     inform_dist *p = inform_dist_alloc(20);
     for (size_t i = 0; i < inform_dist_size(p); ++i)
         inform_dist_set(p, i, inform_random_int(0, 100));
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, p, -1.0)));
-    ASSERT_TRUE(isnan(inform_shannon_cross(p, p, -0.5)));
+    ASSERT_NAN(inform_shannon_cross(p, p, -1.0));
+    ASSERT_NAN(inform_shannon_cross(p, p, -0.5));
     ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 0.0), inform_shannon_cross(p, p, 0.0), 1e-6);
     ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 0.5), inform_shannon_cross(p, p, 0.5), 1e-6);
     ASSERT_DBL_NEAR_TOL(inform_shannon_entropy(p, 1.5), inform_shannon_cross(p, p, 1.5), 1e-6);
@@ -440,7 +440,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR(1/log2(b), got);
     }
 
@@ -448,7 +448,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR(3/(2*log2(b)), got);
     }
 
@@ -456,7 +456,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR(8/(5*log2(b)), got);
     }
 
@@ -464,7 +464,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR(((5*log2(5)-3)/(5*log2(b))), got);
     }
 
@@ -473,7 +473,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR((log2(5)-1)/log2(b), got);
     }
 
@@ -482,7 +482,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR((log2(5)-2)/log2(b), got);
     }
 
@@ -491,7 +491,7 @@ UNIT(ShannonUniCrossEntropyDefined)
     for (double b = 0.0; b <= 4.0; b += 0.5)
     {
         double got = inform_shannon_cross(p, q, b);
-        ASSERT_FALSE(isnan(got));
+        ASSERT_NOT_NAN(got);
         ASSERT_DBL_NEAR(log2(5.0)/log2(b), got);
     }
 

--- a/test/unittests/transfer_entropy.c
+++ b/test/unittests/transfer_entropy.c
@@ -11,12 +11,12 @@ UNIT(TransferEntropyNULLSeries)
     int const series[] = {1,1,0,0,1,0,0,1};
 
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_transfer_entropy(NULL, series, 1, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(NULL, series, 1, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_transfer_entropy(series, NULL, 1, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(series, NULL, 1, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ETIMESERIES, err);
 }
@@ -25,7 +25,7 @@ UNIT(TransferEntropyNoInits)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_transfer_entropy(series, series, 0, 3, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(series, series, 0, 3, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENOINITS, err);
 }
@@ -38,7 +38,7 @@ UNIT(TransferEntropySeriesTooShort)
     for (size_t i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_transfer_entropy(series, series, 1, i, 2, 2, &err)));
+        ASSERT_NAN(inform_transfer_entropy(series, series, 1, i, 2, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_ESHORTSERIES, err);
     }
@@ -51,7 +51,7 @@ UNIT(TransferEntropyHistoryTooLong)
     for (size_t i = 2; i < 4; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_transfer_entropy(series, series, 1, 2, 2, i, &err)));
+        ASSERT_NAN(inform_transfer_entropy(series, series, 1, 2, 2, i, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EKLONG, err);
     }
@@ -61,7 +61,7 @@ UNIT(TransferEntropyZeroHistory)
 {
     int const series[] = {1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_transfer_entropy(series, series, 1, 2, 2, 0, &err)));
+    ASSERT_NAN(inform_transfer_entropy(series, series, 1, 2, 2, 0, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EKZERO, err);
 }
@@ -73,7 +73,7 @@ UNIT(TransferEntropyInvalidBase)
     for (int i = 0; i < 2; ++i)
     {
         err = INFORM_SUCCESS;
-        ASSERT_TRUE(isnan(inform_transfer_entropy(series, series, 1, 2, i, 2, &err)));
+        ASSERT_NAN(inform_transfer_entropy(series, series, 1, 2, i, 2, &err));
         ASSERT_TRUE(inform_failed(&err));
         ASSERT_EQUAL(INFORM_EBASE, err);
     }
@@ -85,12 +85,12 @@ UNIT(TransferEntropyNegativeState)
     int const seriesB[] = {-1,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
 
-    ASSERT_TRUE(isnan(inform_transfer_entropy(seriesA, seriesB, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(seriesA, seriesB, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_transfer_entropy(seriesB, seriesA, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(seriesB, seriesA, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_ENEGSTATE, err);
 }
@@ -101,12 +101,12 @@ UNIT(TransferEntropyBadState)
     int const seriesB[] = {2,1,0,0,1,0,0,1};
     inform_error err = INFORM_SUCCESS;
 
-    ASSERT_TRUE(isnan(inform_transfer_entropy(seriesA, seriesB, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(seriesA, seriesB, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 
     err = INFORM_SUCCESS;
-    ASSERT_TRUE(isnan(inform_transfer_entropy(seriesB, seriesA, 1, 8, 2, 2, &err)));
+    ASSERT_NAN(inform_transfer_entropy(seriesB, seriesA, 1, 8, 2, 2, &err));
     ASSERT_TRUE(inform_failed(&err));
     ASSERT_EQUAL(INFORM_EBADSTATE, err);
 }


### PR DESCRIPTION
This pull request brings in improved assertions for floating-point comparisons, new assertions such as `ASSERT_NAN` and `ASSERT_INF`, and updates all unit tests to use them.

This closes #67 